### PR TITLE
Implement basic course loader with sample course

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # SkillMaster
 
-This repository contains the early prototype of **SkillMaster**, an offline-first study application.
+This repository contains the prototype of **SkillMaster**, an offline-first study application.
 
 - [Design document](docs/design_doc.md)
 - [UI mockup](docs/mockup.html)
 
-The app is built with React and Tauri. This commit provides an initial project skeleton including a basic React application and minimal Tauri setup.
+Run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+A small sample course is included under `course/early_arithmetic/` and referenced by `courses.json`.
+

--- a/course/early_arithmetic/as_md/EA:AS001.md
+++ b/course/early_arithmetic/as_md/EA:AS001.md
@@ -1,0 +1,3 @@
+# Identify numerals 0-9
+
+Recognize and name the written symbols for numbers zero through nine.

--- a/course/early_arithmetic/as_md/EA:AS003.md
+++ b/course/early_arithmetic/as_md/EA:AS003.md
@@ -1,0 +1,3 @@
+# Understand one-to-one correspondence when counting
+
+Match each object in a set with a single number word or numeral when counting.

--- a/course/early_arithmetic/as_md/EA:AS004.md
+++ b/course/early_arithmetic/as_md/EA:AS004.md
@@ -1,0 +1,3 @@
+# Count objects up to 10
+
+Accurately determine the quantity of items in a set containing up to 10 objects.

--- a/course/early_arithmetic/as_md/EA:AS013.md
+++ b/course/early_arithmetic/as_md/EA:AS013.md
@@ -1,0 +1,3 @@
+# Understand and use the plus (+) and equals (=) signs
+
+Recognize and correctly interpret the symbols for addition and equality.

--- a/course/early_arithmetic/as_questions/EA:AS001.yaml
+++ b/course/early_arithmetic/as_questions/EA:AS001.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS001
+pool:
+  - id: q1
+    stem: "Which numeral represents the number three?"
+    choices: ["1", "3", "5", "7"]
+    correct: 1
+  - id: q2
+    stem: "Select the numeral for zero."
+    choices: ["0", "6", "8", "9"]
+    correct: 0

--- a/course/early_arithmetic/as_questions/EA:AS003.yaml
+++ b/course/early_arithmetic/as_questions/EA:AS003.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS003
+pool:
+  - id: q1
+    stem: "When counting four apples, which number do you say last?"
+    choices: ["two", "three", "four", "five"]
+    correct: 2
+  - id: q2
+    stem: "One-to-one correspondence means each object is matched with..."
+    choices: ["any number", "a single number", "two numbers", "no number"]
+    correct: 1

--- a/course/early_arithmetic/as_questions/EA:AS004.yaml
+++ b/course/early_arithmetic/as_questions/EA:AS004.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS004
+pool:
+  - id: q1
+    stem: "Count the stars: ⭐⭐"
+    choices: ["1", "2", "3", "4"]
+    correct: 1
+  - id: q2
+    stem: "How many apples are in a set of 5?"
+    choices: ["3", "4", "5", "6"]
+    correct: 2

--- a/course/early_arithmetic/as_questions/EA:AS013.yaml
+++ b/course/early_arithmetic/as_questions/EA:AS013.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS013
+pool:
+  - id: q1
+    stem: "Which symbol shows addition?"
+    choices: ["−", "+", "×", "="]
+    correct: 1
+  - id: q2
+    stem: "2 + 1 = ___"
+    choices: ["2", "3", "4", "1"]
+    correct: 1

--- a/course/early_arithmetic/catalog.json
+++ b/course/early_arithmetic/catalog.json
@@ -1,0 +1,6 @@
+{
+  "format": "Catalog-v1",
+  "course_id": "EA",
+  "entry_topics": ["EA:T001"],
+  "description": "Early arithmetic fundamentals"
+}

--- a/course/early_arithmetic/topics/EA:T001.json
+++ b/course/early_arithmetic/topics/EA:T001.json
@@ -1,0 +1,8 @@
+{
+  "id": "EA:T001",
+  "name": "Number Sense & Counting",
+  "desc": "Recognize numerals and counting up to 10",
+  "prereqs": [],
+  "weights": {},
+  "ass": ["EA:AS001", "EA:AS003", "EA:AS004"]
+}

--- a/course/early_arithmetic/topics/EA:T002.json
+++ b/course/early_arithmetic/topics/EA:T002.json
@@ -1,0 +1,8 @@
+{
+  "id": "EA:T002",
+  "name": "Basic Addition",
+  "desc": "Understand plus and equals signs",
+  "prereqs": ["EA:T001"],
+  "weights": {"EA:T001": 1.0},
+  "ass": ["EA:AS013"]
+}

--- a/courses.json
+++ b/courses.json
@@ -1,0 +1,6 @@
+{
+  "format": "Courses-v1",
+  "courses": [
+    {"id": "EA", "name": "Early Arithmetic", "path": "course/early_arithmetic/"}
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
+import CourseLibrary from './CourseLibrary';
 
 export default function App() {
+  const [screen, setScreen] = useState<'home' | 'library'>('home');
   return (
-    <div className="text-center p-4">
-      <h1 className="text-2xl font-bold">Skill Mastery</h1>
-      <p className="mt-2">Initial prototype. Refer to the <a href="docs/mockup.html" target="_blank" rel="noopener">mockup</a>.</p>
+    <div style={{ padding: '1rem', textAlign: 'center' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>Skill Mastery</h1>
+      <nav style={{ margin: '1rem 0' }}>
+        <button onClick={() => setScreen('home')} style={{ marginRight: '1rem' }}>
+          Home
+        </button>
+        <button onClick={() => setScreen('library')}>Course Library</button>
+      </nav>
+      {screen === 'home' && (
+        <p>
+          Initial prototype. Refer to the <a href="docs/mockup.html" target="_blank" rel="noopener">mockup</a>.
+        </p>
+      )}
+      {screen === 'library' && <CourseLibrary />}
     </div>
   );
 }

--- a/src/CourseLibrary.tsx
+++ b/src/CourseLibrary.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+import { loadCourses, CourseMeta } from './courseLoader';
+
+export default function CourseLibrary() {
+  const [courses, setCourses] = useState<CourseMeta[]>([]);
+  useEffect(() => {
+    loadCourses().then(setCourses);
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Course Library</h2>
+      {courses.length === 0 && <p>No courses available.</p>}
+      <ul>
+        {courses.map(c => (
+          <li key={c.id}>
+            <strong>{c.name}</strong> ({c.id})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/courseLoader.ts
+++ b/src/courseLoader.ts
@@ -1,0 +1,22 @@
+export interface CourseMeta {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface CoursesFile {
+  format: string;
+  courses: CourseMeta[];
+}
+
+export async function loadCourses(): Promise<CourseMeta[]> {
+  try {
+    const res = await fetch('/courses.json');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data: CoursesFile = await res.json();
+    return data.courses || [];
+  } catch (e) {
+    console.error('Failed to load courses.json', e);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add initial sample course data
- load `courses.json` via new `courseLoader` helper
- display list of courses via `CourseLibrary` component
- simple navigation added in `App`
- update README with run instructions
- add Early Arithmetic sample course

## Testing
- `npm run build`
