### PR TITLE
Add elementary arithmetic sample content

### DIFF
--- a/course/elementary_arithmetic/as_md/EA:AS001.md
+++ b/course/elementary_arithmetic/as_md/EA:AS001.md
@@ -1,0 +1,3 @@
+# Identify numerals 0-9
+
+Recognize and name the written symbols for numbers zero through nine.

--- a/course/elementary_arithmetic/as_md/EA:AS003.md
+++ b/course/elementary_arithmetic/as_md/EA:AS003.md
@@ -1,0 +1,3 @@
+# Understand one-to-one correspondence when counting
+
+Match each object in a set with a single number word or numeral when counting.

--- a/course/elementary_arithmetic/as_md/EA:AS004.md
+++ b/course/elementary_arithmetic/as_md/EA:AS004.md
@@ -1,0 +1,3 @@
+# Count objects up to 10
+
+Accurately determine the quantity of items in a set containing up to 10 objects.

--- a/course/elementary_arithmetic/as_md/EA:AS013.md
+++ b/course/elementary_arithmetic/as_md/EA:AS013.md
@@ -1,0 +1,3 @@
+# Understand and use the plus (+) and equals (=) signs
+
+Recognize and correctly interpret the symbols for addition and equality.

--- a/course/elementary_arithmetic/as_questions/EA:AS001.yaml
+++ b/course/elementary_arithmetic/as_questions/EA:AS001.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS001
+pool:
+  - id: q1
+    stem: "Which numeral represents the number three?"
+    choices: ["1", "3", "5", "7"]
+    correct: 1
+  - id: q2
+    stem: "Select the numeral for zero."
+    choices: ["0", "6", "8", "9"]
+    correct: 0

--- a/course/elementary_arithmetic/as_questions/EA:AS003.yaml
+++ b/course/elementary_arithmetic/as_questions/EA:AS003.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS003
+pool:
+  - id: q1
+    stem: "How many counters do you have if you place one counter on each of six spots?"
+    choices: ["5", "6", "7", "8"]
+    correct: 1
+  - id: q2
+    stem: "Point to the object counted as number four in a row of items. What is its position?"
+    choices: ["1st", "2nd", "4th", "5th"]
+    correct: 2

--- a/course/elementary_arithmetic/as_questions/EA:AS004.yaml
+++ b/course/elementary_arithmetic/as_questions/EA:AS004.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS004
+pool:
+  - id: q1
+    stem: "Count the apples: 🍎🍎🍎. How many are there?"
+    choices: ["2", "3", "4", "5"]
+    correct: 1
+  - id: q2
+    stem: "If you see seven ducks in a pond, which number shows how many ducks there are?"
+    choices: ["6", "7", "8", "9"]
+    correct: 1

--- a/course/elementary_arithmetic/as_questions/EA:AS013.yaml
+++ b/course/elementary_arithmetic/as_questions/EA:AS013.yaml
@@ -1,0 +1,11 @@
+format: ASQ-v1
+id: EA_AS013
+pool:
+  - id: q1
+    stem: "Which symbol shows addition?"
+    choices: ["−", "+", "×", "="]
+    correct: 1
+  - id: q2
+    stem: "2 + 1 = ___"
+    choices: ["2", "3", "4", "1"]
+    correct: 1

--- a/course/elementary_arithmetic/catalog.json
+++ b/course/elementary_arithmetic/catalog.json
@@ -1,0 +1,6 @@
+{
+  "format": "Catalog-v1",
+  "course_id": "EA",
+  "entry_topics": ["EA:T001"],
+  "description": "Early arithmetic fundamentals"
+}

--- a/course/elementary_arithmetic/prereqs.csv
+++ b/course/elementary_arithmetic/prereqs.csv
@@ -1,0 +1,4 @@
+source_skill_id,destination_skill_id,weight
+EA:AS001,EA:AS004,1.0
+EA:AS003,EA:AS004,1.0
+EA:AS001,EA:AS013,1.0

--- a/course/elementary_arithmetic/topics/EA:T001.json
+++ b/course/elementary_arithmetic/topics/EA:T001.json
@@ -1,0 +1,8 @@
+{
+  "id": "EA:T001",
+  "name": "Number Sense & Counting",
+  "desc": "Recognize numerals and basic counting skills",
+  "prereqs": [],
+  "weights": {},
+  "ass": ["EA:AS001", "EA:AS003", "EA:AS004"]
+}

--- a/course/elementary_arithmetic/topics/EA:T002.json
+++ b/course/elementary_arithmetic/topics/EA:T002.json
@@ -1,0 +1,8 @@
+{
+  "id": "EA:T002",
+  "name": "Basic Addition",
+  "desc": "Understand use of plus and equals signs",
+  "prereqs": ["EA:T001"],
+  "weights": {"EA:T001": 1.0},
+  "ass": ["EA:AS013"]
+}


### PR DESCRIPTION
## Summary
- add sample course content for Elementary Arithmetic
- implement topics and atomic skill stubs

## Testing
- `jq . course/elementary_arithmetic/catalog.json`
- `jq . course/elementary_arithmetic/topics/EA:T001.json`
- `jq . course/elementary_arithmetic/topics/EA:T002.json`
