### PR TITLE
Persist user preferences

### DIFF
--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,0 +1,31 @@
+export interface Prefs {
+  xp_since_mixed_quiz: number;
+  last_as: string;
+  ui_theme: 'default' | 'dark';
+}
+
+const DEFAULT_PREFS: Prefs = {
+  xp_since_mixed_quiz: 0,
+  last_as: '',
+  ui_theme: 'default'
+};
+
+export function loadPrefs(): Prefs {
+  try {
+    const raw = localStorage.getItem('prefs');
+    if (!raw) return { ...DEFAULT_PREFS };
+    const obj = JSON.parse(raw);
+    return { ...DEFAULT_PREFS, ...obj } as Prefs;
+  } catch (e) {
+    console.error('Failed to load prefs', e);
+    return { ...DEFAULT_PREFS };
+  }
+}
+
+export function savePrefs(p: Prefs) {
+  try {
+    localStorage.setItem('prefs', JSON.stringify(p));
+  } catch (e) {
+    console.error('Failed to save prefs', e);
+  }
+}


### PR DESCRIPTION
## Summary
- remember user-selected dark mode using prefs storage
- track last completed AS id
- add local `prefs` utilities

## Testing
- `npm test`
