### PR TITLE
Add schema validation tooling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@ file before committing.
 ## Core Data & Storage
 - [ ] Implement filesystem layout (`courses.json`, `course/<id>/`, `save/`, `.cache/`, etc.).
 - [ ] Build loader that demand-loads topic and skill files and automatically rebuilds `.cache/index.db` with distance matrix (Floyd–Warshall).
-- [ ] Define JSON schemas in `schema/` and validate content and save files via AJV.
 - [ ] Implement persistence of save data (`mastery.json`, `attempt_window.json`, `xp.json`, `prefs.json`) with atomic writes and autosave after every answer.
 - [ ] Support optional multi-profile folders as per `prefs.json` section.
 - [ ] Provide logging to `logs/error.log` and `logs/debug.log` with rotation.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "tauri": "npx tauri"
+    "tauri": "npx tauri",
+    "test": "node ./scripts/validate.mjs"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/schema/asq-v1.json
+++ b/schema/asq-v1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "format": {"const": "ASQ-v1"},
+    "id": {"type": "string"},
+    "pool": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "stem": {"type": "string"},
+          "choices": {"type": "array", "minItems": 2, "items": {"type": "string"}},
+          "correct": {"type": "integer", "minimum": 0},
+          "solution": {"type": "string"}
+        },
+        "required": ["id", "stem", "choices", "correct"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["format", "id", "pool"],
+  "additionalProperties": false
+}

--- a/schema/attempts-v1.json
+++ b/schema/attempts-v1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "format": {"const": "Attempts-v1"},
+    "ass": {
+      "type": "object",
+      "additionalProperties": {"type": "array", "items": {"type": "number"}}
+    },
+    "topics": {
+      "type": "object",
+      "additionalProperties": {"type": "array", "items": {"type": "number"}}
+    }
+  },
+  "required": ["format", "ass", "topics"],
+  "additionalProperties": false
+}

--- a/schema/catalog-v1.json
+++ b/schema/catalog-v1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "format": {"const": "Catalog-v1"},
+    "course_id": {"type": "string"},
+    "entry_topics": {"type": "array", "items": {"type": "string"}},
+    "description": {"type": "string"}
+  },
+  "required": ["format", "course_id", "entry_topics", "description"],
+  "additionalProperties": false
+}

--- a/schema/courses-v1.json
+++ b/schema/courses-v1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "format": {"const": "Courses-v1"},
+    "courses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "path"],
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "path": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["format", "courses"],
+  "additionalProperties": false
+}

--- a/schema/mastery-v2.json
+++ b/schema/mastery-v2.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "format": {"const": "Mastery-v2"},
+    "ass": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string"},
+          "s": {"type": "number"},
+          "d": {"type": "number"},
+          "r": {"type": "number"},
+          "l": {"type": "number"},
+          "next_due": {"type": "string"},
+          "next_q_index": {"type": "integer"}
+        },
+        "required": ["status", "s", "d", "r", "l", "next_due", "next_q_index"],
+        "additionalProperties": false
+      }
+    },
+    "topics": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string"},
+          "last_quiz_score": {"type": "number"},
+          "last_quiz_date": {"type": "string"}
+        },
+        "required": ["status", "last_quiz_score", "last_quiz_date"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["format", "ass", "topics"],
+  "additionalProperties": false
+}

--- a/schema/prefs-v1.json
+++ b/schema/prefs-v1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "xp_since_mixed_quiz": {"type": "number"},
+    "last_as": {"type": ["string", "null"]},
+    "ui_theme": {"type": "string"}
+  },
+  "required": ["xp_since_mixed_quiz", "last_as", "ui_theme"],
+  "additionalProperties": false
+}

--- a/schema/skill-v1.json
+++ b/schema/skill-v1.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "name": {"type": "string"},
+    "prereqs": {"type": "array", "items": {"type": "string"}},
+    "weights": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {"type": "number"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["id", "name"],
+  "additionalProperties": false
+}

--- a/schema/topic-v1.json
+++ b/schema/topic-v1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "name": {"type": "string"},
+    "ass": {"type": "array", "items": {"type": "string"}}
+  },
+  "required": ["id", "name", "ass"],
+  "additionalProperties": false
+}

--- a/schema/xp-v1.json
+++ b/schema/xp-v1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "format": {"const": "XP-v1"},
+    "log": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "ts", "delta", "source"],
+        "properties": {
+          "id": {"type": "integer"},
+          "ts": {"type": "string"},
+          "delta": {"type": "number"},
+          "source": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["format", "log"],
+  "additionalProperties": false
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Ajv from 'ajv';
+import yaml from 'js-yaml';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const schemaDir = path.join(root, 'schema');
+
+function readJSON(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function readYAML(p) {
+  return yaml.load(fs.readFileSync(p, 'utf8'));
+}
+
+const ajv = new Ajv({ allErrors: true });
+
+function compile(name) {
+  return ajv.compile(readJSON(path.join(schemaDir, name)));
+}
+
+const schemas = {
+  courses: compile('courses-v1.json'),
+  catalog: compile('catalog-v1.json'),
+  topic: compile('topic-v1.json'),
+  skill: compile('skill-v1.json'),
+  asq: compile('asq-v1.json'),
+  mastery: compile('mastery-v2.json'),
+  attempts: compile('attempts-v1.json'),
+  xp: compile('xp-v1.json'),
+  prefs: compile('prefs-v1.json')
+};
+
+function validate(file, schema) {
+  const data = file.endsWith('.yaml') ? readYAML(file) : readJSON(file);
+  if (!schema(data)) {
+    console.error('Validation failed:', file);
+    console.error(schema.errors);
+    return false;
+  }
+  return true;
+}
+
+let ok = true;
+
+ok &= validate(path.join(root, 'courses.json'), schemas.courses);
+
+const courseDir = path.join(root, 'course', 'ea');
+ok &= validate(path.join(courseDir, 'catalog.json'), schemas.catalog);
+for (const f of fs.readdirSync(path.join(courseDir, 'topics'))) {
+  ok &= validate(path.join(courseDir, 'topics', f), schemas.topic);
+}
+for (const f of fs.readdirSync(path.join(courseDir, 'skills'))) {
+  ok &= validate(path.join(courseDir, 'skills', f), schemas.skill);
+}
+for (const f of fs.readdirSync(path.join(courseDir, 'as_questions'))) {
+  ok &= validate(path.join(courseDir, 'as_questions', f), schemas.asq);
+}
+const saveMapping = {
+  'mastery.json': schemas.mastery,
+  'attempt_window.json': schemas.attempts,
+  'xp.json': schemas.xp,
+  'prefs.json': schemas.prefs
+};
+for (const [file, schema] of Object.entries(saveMapping)) {
+  ok &= validate(path.join(root, 'save', file), schema);
+}
+
+if (!ok) {
+  process.exit(1);
+} else {
+  console.log('All files valid');
+}


### PR DESCRIPTION
## Summary
- implement JSON schemas in `schema/`
- add validation script using AJV and js-yaml
- wire `npm test` to run validator
- remove completed item from TODO

## Testing
- `npm test`
- `npm run tauri dev` *(fails: Failed to initialize GTK)*