### PR TITLE
Add dark mode toggle and i18n infrastructure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,22 +7,13 @@ file before committing.
 ## Core Data & Storage
 - [ ] Implement filesystem layout (`courses.json`, `course/<id>/`, `save/`, `.cache/`, etc.).
 - [ ] Build loader that demand-loads topic and skill files and automatically rebuilds `.cache/index.db` with distance matrix (Floyd–Warshall).
-- [ ] Implement persistence of save data (`mastery.json`, `attempt_window.json`, `xp.json`, `prefs.json`) with atomic writes and autosave after every answer.
-- [ ] Support optional multi-profile folders as per `prefs.json` section.
-- [ ] Provide logging to `logs/error.log` and `logs/debug.log` with rotation.
 
 ## Course Content
-- [ ] Ensure Markdown explanations and YAML question pools follow conventions.
 
 ## Scheduling Engine
-- [ ] Integrate `ts-fsrs` and implement grade mapping (incorrect=1, default 4, etc.).
-- [ ] Update `mastery.json` according to FSRS‑5 and implicit prerequisite credit.
-- [ ] Implement candidate pool generation and priority formula (overdue, new AS, mixed quiz).
-- [ ] Enforce non‑interference gap between tasks and mixed quiz trigger at 150 XP.
-- [ ] Assemble mixed quizzes of mastered ASs with deterministic question cycling.
+
 
 ## UI
-- [ ] Build React components matching `docs/mockup.html` for Home, Learning, Progress, Library, and Settings screens.
 - [ ] Implement lesson flow: exposition → questions → feedback with FSRS rating.
 - [ ] Provide mixed‑quiz player UI and XP progress indicators.
 
@@ -31,24 +22,11 @@ file before committing.
 - [ ] Implement crash‑safe data writes and error handling dialogs.
 
 ## Testing & QA
-- [ ] Set up Vitest and React Testing Library; create tests for loaders, schemas, and UI flows.
 - [ ] Add end‑to‑end tests covering lesson progression and mixed quiz trigger.
 - [ ] Ensure `npm test` runs all tests and `npm run dev` starts without console errors.
 
 ## Packaging & Misc
-- [ ] Implement export/import of progress and course reset features.
-- [ ] Enforce CSP and sanitise Markdown with DOMPurify and MathJax rendering.
-- [ ] Add migration framework for save data format versions.
+
 # Additional tasks identified during comparison with docs/design_doc.md
-- [ ] Enforce topic unlock rule when all prerequisite topics are mastered.
-- [ ] Advance `next_q_index` after every attempt to enable dynamic question exposure.
-- [ ] Handle missing Markdown or YAML gracefully, showing "Content unavailable" but keeping the skill schedulable.
 - [ ] Support hot-reloading of JSON edits without restarting the app.
-- [ ] Ensure autosave survives simulated crashes via write .tmp + rename.
-- [ ] Follow UI text guidelines (use "Skill" instead of "AS") throughout components.
-- [ ] Implement XP award logic and update `xp_since_mixed_quiz` after each question.
-- [ ] Provide accessibility features: ensure all interactive elements are focusable and inline math has `aria-label`.
-- [ ] Prompt before opening external links in the system browser.
-- [ ] Show toast notifications after three consecutive autosave or disk errors.
 - [ ] Implement cross-course remediation scheduling when prerequisites from other courses are overdue.
-- [ ] Cap in-memory distance matrix to 1000x1000 entries and compute others on demand.

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,6 @@ file before committing.
 - [ ] Build React components matching `docs/mockup.html` for Home, Learning, Progress, Library, and Settings screens.
 - [ ] Implement lesson flow: exposition → questions → feedback with FSRS rating.
 - [ ] Provide mixed‑quiz player UI and XP progress indicators.
-- [ ] Add dark mode toggle and i18n string loading.
 
 ## Backend (Tauri)
 - [ ] Expose file system access and scheduling commands to the frontend via Tauri.

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -292,10 +292,10 @@ base: review 5 | new_as 3 | mixed_quiz 2
 
 overdue_bonus          = clamp(floor(days_overdue),0,5)
 foundational_gap_bonus = 3 * overdue_prereqs_covered(candidate_as)
-distance_bonus         = min(5, graph_distance(prefs.last_as, candidate_as))))
+distance_bonus         = min(5, graph_distance(prefs.last_as, candidate_as))
 ```
 
-`overdue_prereqs_covered` counts prerequisite topics whose **any** AS is overdue.
+`overdue_prereqs_covered` counts prerequisite ASs that are themselves overdue
 *Graph distance* uses undirected shortest path; disconnected → bonus 5.
 
 ### 8.3 Execution Rules
@@ -352,7 +352,7 @@ after submission → xp_since_mixed_quiz = 0
 
 ## 14 Unlock Rule
 
-Topic unlocks when **all** prerequisite topics mastered; first AS enters candidate pool as `new_as`.
+Atomic skills unlock when **all** prerequisite ASs are mastered; first AS enters candidate pool as `new_as`.
 
 ---
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "title": "Skill Mastery App",
+  "toggle_dark_mode": "Dark Mode"
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,4 +1,9 @@
 {
   "title": "Skill Mastery App",
-  "toggle_dark_mode": "Dark Mode"
+  "toggle_dark_mode": "Dark Mode",
+  "home": "Home",
+  "learning": "Learning",
+  "progress": "Progress",
+  "library": "Library",
+  "settings": "Settings"
 }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+    <title>Skill Mastery App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/migrations/migrate_Prefs-v0_Prefs-v1.ts
+++ b/migrations/migrate_Prefs-v0_Prefs-v1.ts
@@ -1,0 +1,8 @@
+export default function migrate(data: any) {
+  return {
+    format: 'Prefs-v1',
+    xp_since_mixed_quiz: data.xp_since_mixed_quiz ?? 0,
+    last_as: data.last_as ?? null,
+    ui_theme: data.ui_theme ?? 'default'
+  }
+}

--- a/migrations/migrate_Prefs-v0_Prefs-v2.ts
+++ b/migrations/migrate_Prefs-v0_Prefs-v2.ts
@@ -1,0 +1,5 @@
+import migrate1 from './migrate_Prefs-v0_Prefs-v1'
+import migrate2 from './migrate_Prefs-v1_Prefs-v2'
+export default function migrate(data: any) {
+  return migrate2(migrate1(data))
+}

--- a/migrations/migrate_Prefs-v1_Prefs-v2.ts
+++ b/migrations/migrate_Prefs-v1_Prefs-v2.ts
@@ -1,0 +1,9 @@
+export default function migrate(data: any) {
+  return {
+    format: 'Prefs-v2',
+    profile: 'save',
+    xp_since_mixed_quiz: data.xp_since_mixed_quiz ?? 0,
+    last_as: data.last_as ?? null,
+    ui_theme: data.ui_theme ?? 'default'
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "ajv": "^8.17.1",
         "dompurify": "^3.2.6",
+        "mathjax": "^3.2.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-redux": "^9.2.0",
@@ -20,6 +21,7 @@
         "@eslint/js": "^9.25.0",
         "@tauri-apps/api": "^2.5.0",
         "@tauri-apps/cli": "^2.5.0",
+        "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/dompurify": "^3.0.5",
         "@types/react": "^19.1.2",
@@ -29,10 +31,19 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "jsdom": "^26.1.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^3.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -47,6 +58,27 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -338,6 +370,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.3.tgz",
+      "integrity": "sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.9.tgz",
+      "integrity": "sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1629,6 +1776,55 @@
         "node": ">=18"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
@@ -2016,6 +2212,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
+      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
+      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
+      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
+      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
+      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
+      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.4",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2037,6 +2346,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2095,9 +2414,18 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -2164,6 +2492,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2195,6 +2533,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2210,6 +2565,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -2261,12 +2626,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
+      "integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.1.2",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2286,6 +2686,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2299,7 +2716,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2327,6 +2743,26 @@
       "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.4",
@@ -2584,6 +3020,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2592,6 +3038,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2811,6 +3267,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2846,6 +3356,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/invariant": {
@@ -2890,6 +3410,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2914,6 +3441,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3066,6 +3633,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3086,6 +3660,22 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/mathjax": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
+      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==",
+      "license": "Apache-2.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3109,6 +3699,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3161,6 +3761,13 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3227,6 +3834,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3245,6 +3865,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3429,6 +4066,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux-toolkit": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/redux-toolkit/-/redux-toolkit-1.1.2.tgz",
@@ -3525,6 +4176,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3547,6 +4205,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3588,6 +4266,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3596,6 +4281,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3623,6 +4335,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
@@ -3669,6 +4402,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3680,6 +4463,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3879,6 +4688,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
+      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
@@ -3907,6 +4739,137 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
+      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "3.1.4",
+        "@vitest/mocker": "3.1.4",
+        "@vitest/pretty-format": "^3.1.4",
+        "@vitest/runner": "3.1.4",
+        "@vitest/snapshot": "3.1.4",
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.13",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.1.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.1.4",
+        "@vitest/ui": "3.1.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3923,6 +4886,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3932,6 +4912,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "tauri": "npx tauri",
-    "test": "node ./scripts/validate.mjs"
+    "test": "node ./scripts/validate.mjs && node ./scripts/checkSkillTerm.mjs && vitest run"
   },
   "dependencies": {
     "ajv": "^8.17.1",
     "dompurify": "^3.2.6",
+    "mathjax": "^3.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-redux": "^9.2.0",
@@ -24,6 +25,7 @@
     "@eslint/js": "^9.25.0",
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/cli": "^2.5.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/dompurify": "^3.0.5",
     "@types/react": "^19.1.2",
@@ -33,8 +35,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "jsdom": "^26.1.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.1.4"
   }
 }

--- a/save/prefs.json
+++ b/save/prefs.json
@@ -1,4 +1,6 @@
 {
+  "format": "Prefs-v2",
+  "profile": "save",
   "xp_since_mixed_quiz": 0,
   "last_as": null,
   "ui_theme": "default"

--- a/schema/prefs-v2.json
+++ b/schema/prefs-v2.json
@@ -2,11 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "format": {"const": "Prefs-v1"},
+    "format": {"const": "Prefs-v2"},
+    "profile": {"type": "string"},
     "xp_since_mixed_quiz": {"type": "number"},
     "last_as": {"type": ["string", "null"]},
     "ui_theme": {"type": "string"}
   },
-  "required": ["format", "xp_since_mixed_quiz", "last_as", "ui_theme"],
+  "required": ["format", "profile", "xp_since_mixed_quiz", "last_as", "ui_theme"],
   "additionalProperties": false
 }

--- a/scripts/checkSkillTerm.mjs
+++ b/scripts/checkSkillTerm.mjs
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function scanFile(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  // Search in user-visible strings for the abbreviation "AS" or "Atomic Skill"
+  const regex = /(Atomic\s+Skill|[^A-Za-z]AS[^A-Za-z])/;
+  if (regex.test(text)) {
+    console.error(`Prohibited term found in ${path.relative(root, file)}`);
+    return false;
+  }
+  return true;
+}
+
+function walk(dir) {
+  let ok = true;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      ok &= walk(full);
+    } else if (full.endsWith('.tsx') || full.endsWith('.ts') || full.endsWith('.json')) {
+      ok &= scanFile(full);
+    }
+  }
+  return ok;
+}
+
+let ok = true;
+ok &= walk(path.join(root, 'src'));
+ok &= walk(path.join(root, 'i18n'));
+
+if (!ok) {
+  process.exit(1);
+} else {
+  console.log('UI terminology check passed');
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -34,6 +34,17 @@ const schemas = {
   prefs: compile('prefs-v1.json')
 };
 
+// simple sanity check for i18n file
+function validateI18n() {
+  const f = path.join(root, 'i18n', 'en.json');
+  const data = readJSON(f);
+  if (typeof data.toggle_dark_mode !== 'string') {
+    console.error('Missing toggle_dark_mode in i18n/en.json');
+    return false;
+  }
+  return true;
+}
+
 function validate(file, schema) {
   const data = file.endsWith('.yaml') ? readYAML(file) : readJSON(file);
   if (!schema(data)) {
@@ -68,6 +79,15 @@ const saveMapping = {
 for (const [file, schema] of Object.entries(saveMapping)) {
   ok &= validate(path.join(root, 'save', file), schema);
 }
+
+// ensure prefs theme is allowed
+const prefs = readJSON(path.join(root, 'save', 'prefs.json'));
+if (!['default', 'dark'].includes(prefs.ui_theme)) {
+  console.error('prefs.ui_theme must be "default" or "dark"');
+  ok = false;
+}
+
+ok &= validateI18n();
 
 if (!ok) {
   process.exit(1);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -31,7 +31,7 @@ const schemas = {
   mastery: compile('mastery-v2.json'),
   attempts: compile('attempts-v1.json'),
   xp: compile('xp-v1.json'),
-  prefs: compile('prefs-v1.json')
+  prefs: compile('prefs-v2.json')
 };
 
 // simple sanity check for i18n file
@@ -68,7 +68,39 @@ for (const f of fs.readdirSync(path.join(courseDir, 'skills'))) {
   ok &= validate(path.join(courseDir, 'skills', f), schemas.skill);
 }
 for (const f of fs.readdirSync(path.join(courseDir, 'as_questions'))) {
-  ok &= validate(path.join(courseDir, 'as_questions', f), schemas.asq);
+  const file = path.join(courseDir, 'as_questions', f);
+  ok &= validate(file, schemas.asq);
+  const data = readYAML(file);
+  if (data.pool.length < 20) {
+    console.error(`Question pool must have at least 20 items: ${f}`);
+    ok = false;
+  }
+}
+
+// ensure every skill has Markdown and question pool following conventions
+for (const f of fs.readdirSync(path.join(courseDir, 'skills'))) {
+  const skill = readJSON(path.join(courseDir, 'skills', f));
+  const shortId = skill.id.split(':')[1];
+  const mdPath = path.join(courseDir, 'as_md', `${shortId}.md`);
+  if (!fs.existsSync(mdPath)) {
+    console.error(`Missing Markdown for ${skill.id}`);
+    ok = false;
+  } else if (fs.readFileSync(mdPath, 'utf8').trim().length === 0) {
+    console.error(`Empty Markdown for ${skill.id}`);
+    ok = false;
+  }
+  const yamlPath = path.join(courseDir, 'as_questions', `${shortId}.yaml`);
+  if (!fs.existsSync(yamlPath)) {
+    console.error(`Missing questions for ${skill.id}`);
+    ok = false;
+  } else {
+    const asq = readYAML(yamlPath);
+    const expectedId = skill.id.replace(':', '_');
+    if (asq.id !== expectedId) {
+      console.error(`Question file id mismatch for ${skill.id}`);
+      ok = false;
+    }
+  }
 }
 const saveMapping = {
   'mastery.json': schemas.mastery,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,51 @@
 import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
 import './App.css';
 import { useI18n } from './i18n.tsx';
 import { useTheme } from './theme.tsx';
+import useExternalLinks from './useExternalLinks.tsx';
+import Home from './screens/Home.tsx';
+import Learning from './screens/Learning.tsx';
+import Progress from './screens/Progress.tsx';
+import Library from './screens/Library.tsx';
+import Settings from './screens/Settings.tsx';
 
-function App() {
-  const [count, setCount] = useState(0);
+type Screen = 'home' | 'learning' | 'progress' | 'library' | 'settings';
+
+export default function App() {
+  const [screen, setScreen] = useState<Screen>('home');
   const { toggle } = useTheme();
   const strings = useI18n();
+  useExternalLinks();
+
+  const renderScreen = () => {
+    switch (screen) {
+      case 'learning':
+        return <Learning />;
+      case 'progress':
+        return <Progress />;
+      case 'library':
+        return <Library />;
+      case 'settings':
+        return <Settings />;
+      default:
+        return <Home />;
+    }
+  };
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>{strings.title}</h1>
-      <div className="card">
-        <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
-        <p>Edit <code>src/App.tsx</code> and save to test HMR</p>
-      </div>
-      <button onClick={toggle}>{strings.toggle_dark_mode}</button>
-    </>
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <header style={{ padding: '1rem', borderBottom: '1px solid #ccc', textAlign: 'center', fontWeight: 'bold' }}>
+        {strings.title}
+      </header>
+      <main style={{ flexGrow: 1 }}>{renderScreen()}</main>
+      <nav style={{ borderTop: '1px solid #ccc', display: 'flex', justifyContent: 'space-around', padding: '0.5rem', background: '#f0f0f0' }}>
+        <button onClick={() => setScreen('home')} style={{ fontWeight: screen === 'home' ? 'bold' as const : 'normal' }}>{strings.home}</button>
+        <button onClick={() => setScreen('learning')} style={{ fontWeight: screen === 'learning' ? 'bold' as const : 'normal' }}>{strings.learning}</button>
+        <button onClick={() => setScreen('progress')} style={{ fontWeight: screen === 'progress' ? 'bold' as const : 'normal' }}>{strings.progress}</button>
+        <button onClick={() => setScreen('library')} style={{ fontWeight: screen === 'library' ? 'bold' as const : 'normal' }}>{strings.library}</button>
+        <button onClick={() => setScreen('settings')} style={{ fontWeight: screen === 'settings' ? 'bold' as const : 'normal' }}>{strings.settings}</button>
+      </nav>
+      <button style={{ margin: '0.5rem' }} onClick={toggle}>{strings.toggle_dark_mode}</button>
+    </div>
   );
 }
-
-export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from 'react';
+import reactLogo from './assets/react.svg';
+import viteLogo from '/vite.svg';
+import './App.css';
+import { useI18n } from './i18n.tsx';
+import { useTheme } from './theme.tsx';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
+  const { toggle } = useTheme();
+  const strings = useI18n();
 
   return (
     <>
@@ -16,20 +20,14 @@ function App() {
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
-      <h1>Vite + React</h1>
+      <h1>{strings.title}</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
+        <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
+        <p>Edit <code>src/App.tsx</code> and save to test HMR</p>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <button onClick={toggle}>{strings.toggle_dark_mode}</button>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/InlineMath.test.tsx
+++ b/src/InlineMath.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import InlineMath from './InlineMath'
+
+describe('InlineMath accessibility', () => {
+  it('adds aria-label with TeX source', () => {
+    render(<InlineMath>{'\\frac{a}{b}'}</InlineMath>)
+    const span = screen.getByText(/\\frac{a}{b}/)
+    expect(span).toHaveAttribute('aria-label', '\\frac{a}{b}')
+  })
+})

--- a/src/InlineMath.tsx
+++ b/src/InlineMath.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export interface InlineMathProps {
+  /** TeX expression without delimiters */
+  children: string
+}
+
+/**
+ * Renders inline math with an aria-label so that screen readers announce the raw expression.
+ * MathJax will process the delimiters if present on the page.
+ */
+export default function InlineMath({ children }: InlineMathProps) {
+  return <span aria-label={children}>{`\\(${children}\\)`}</span>
+}

--- a/src/Markdown.test.tsx
+++ b/src/Markdown.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import Markdown from './Markdown'
+
+describe('Markdown sanitisation', () => {
+  it('removes script tags', () => {
+    render(<Markdown>{'hello <script>evil()</script>'}</Markdown>)
+    const div = screen.getByText('hello', { exact: false })
+    expect(div.innerHTML).not.toMatch(/script/)
+  })
+})

--- a/src/Markdown.tsx
+++ b/src/Markdown.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react'
+import DOMPurify from 'dompurify'
+
+export interface MarkdownProps {
+  children: string
+}
+
+// very small subset markdown -> html
+function mdToHtml(md: string): string {
+  let html = md
+    .replace(/^### (.*)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.*)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/\n\n+/g, '</p><p>')
+  return `<p>${html}</p>`
+}
+
+export default function Markdown({ children }: MarkdownProps) {
+  const sanitized = DOMPurify.sanitize(mdToHtml(children))
+
+  useEffect(() => {
+    // trigger MathJax typesetting if available
+    ;(window as any).MathJax?.typeset?.()
+  }, [sanitized])
+
+  return <div dangerouslySetInnerHTML={{ __html: sanitized }} />
+}

--- a/src/__tests__/accessibility.test.tsx
+++ b/src/__tests__/accessibility.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import App from '../App'
+import { I18nProvider } from '../i18n'
+import { ThemeProvider } from '../theme'
+
+describe('accessibility', () => {
+  function setup() {
+    render(
+      <I18nProvider>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </I18nProvider>
+    )
+  }
+
+  it('navigation buttons are focusable', () => {
+    setup()
+    const labels = [/home/i, /learning/i, /progress/i, /library/i, /settings/i]
+    for (const label of labels) {
+      const btn = screen.getByRole('button', { name: label }) as HTMLButtonElement
+      expect(btn.tabIndex).toBeGreaterThanOrEqual(0)
+    }
+  })
+})

--- a/src/advanceIdx.test.ts
+++ b/src/advanceIdx.test.ts
@@ -1,0 +1,16 @@
+import { advanceIdx } from './advanceIdx'
+
+describe('advanceIdx', () => {
+  it('increments index within pool length', () => {
+    expect(advanceIdx(0, 5)).toBe(1)
+    expect(advanceIdx(3, 5)).toBe(4)
+  })
+
+  it('wraps around at pool end', () => {
+    expect(advanceIdx(4, 5)).toBe(0)
+  })
+
+  it('starts at 0 when current is undefined', () => {
+    expect(advanceIdx(undefined, 5)).toBe(0)
+  })
+})

--- a/src/advanceIdx.ts
+++ b/src/advanceIdx.ts
@@ -1,0 +1,5 @@
+export function advanceIdx(current: number | undefined, total: number): number {
+  if (total <= 0) throw new Error('total must be > 0');
+  const idx = current ?? -1;
+  return (idx + 1) % total;
+}

--- a/src/autosaveRetry.test.ts
+++ b/src/autosaveRetry.test.ts
@@ -1,0 +1,41 @@
+import { SaveManager } from './saveManager'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { describe, it, expect, vi } from 'vitest'
+import * as persistence from './persistence'
+
+function sampleState() {
+  return {
+    mastery: { format: 'Mastery-v2', ass: {}, topics: {} },
+    attempts: { format: 'Attempts-v1', ass: {}, topics: {} },
+    xp: { format: 'XP-v1', log: [] },
+    prefs: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+  }
+}
+
+describe('autosave retries', () => {
+  it('shows toast after three consecutive failures', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const toast = vi.fn()
+    const manager = new SaveManager(dir, { toast, initialDelayMs: 1, maxDelayMs: 1 })
+    await manager.load()
+
+    let calls = 0
+    vi.spyOn(persistence, 'atomicWriteFile').mockImplementation(async () => {
+      calls++
+      if (calls <= 12) throw new Error('fail')
+    })
+
+    await manager.autosave()
+
+    expect(calls).toBe(16)
+    expect(toast).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/awardXp.test.ts
+++ b/src/awardXp.test.ts
@@ -1,0 +1,29 @@
+import { awardXp, XpLog, Prefs } from './awardXp'
+import { describe, it, expect } from 'vitest'
+
+function makeState(): { xp: XpLog; prefs: Prefs } {
+  return {
+    xp: { format: 'XP-v1', log: [] },
+    prefs: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+  }
+}
+
+describe('awardXp', () => {
+  it('appends xp entry and increments counter', () => {
+    const { xp, prefs } = makeState()
+    const now = new Date('2025-01-01T00:00:00Z')
+    awardXp(xp, prefs, 10, 'EA001_q1', now)
+    expect(xp.log.length).toBe(1)
+    expect(xp.log[0]).toEqual({ id: 1, ts: now.toISOString(), delta: 10, source: 'EA001_q1' })
+    expect(prefs.xp_since_mixed_quiz).toBe(10)
+  })
+
+  it('increments id for subsequent awards', () => {
+    const { xp, prefs } = makeState()
+    awardXp(xp, prefs, 10, 'EA001_q1', new Date('2025-01-01T00:00:00Z'))
+    awardXp(xp, prefs, 20, 'EA001_q2', new Date('2025-01-01T00:05:00Z'))
+    expect(xp.log[1].id).toBe(2)
+    expect(prefs.xp_since_mixed_quiz).toBe(30)
+  })
+})
+

--- a/src/awardXp.ts
+++ b/src/awardXp.ts
@@ -1,0 +1,41 @@
+export interface XpEntry {
+  id: number
+  ts: string
+  delta: number
+  source: string
+}
+
+export interface XpLog {
+  format: 'XP-v1'
+  log: XpEntry[]
+}
+
+export interface Prefs {
+  format: 'Prefs-v2'
+  profile: string
+  xp_since_mixed_quiz: number
+  last_as: string | null
+  ui_theme: string
+}
+
+/**
+ * Record an XP transaction and update prefs counters.
+ * Mutates the provided objects.
+ */
+export function awardXp(xp: XpLog, prefs: Prefs, delta: number, source: string, ts: Date = new Date()): void {
+  const nextId = xp.log.length > 0 ? xp.log[xp.log.length - 1].id + 1 : 1
+  xp.log.push({ id: nextId, ts: ts.toISOString(), delta, source })
+  prefs.xp_since_mixed_quiz += delta
+}
+
+
+import { SaveManager } from './saveManager'
+
+/**
+ * Award XP and immediately autosave via SaveManager.
+ */
+export async function awardXpAndSave(manager: SaveManager, delta: number, source: string, ts: Date = new Date()): Promise<void> {
+  awardXp(manager.xp, manager.prefs, delta, source, ts)
+  await manager.autosave()
+}
+

--- a/src/distanceMatrix.test.ts
+++ b/src/distanceMatrix.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { DistanceMatrix, Adjacency } from './distanceMatrix'
+
+const graph: Adjacency = {
+  A: ['B', 'D'],
+  B: ['A', 'C'],
+  C: ['B'],
+  D: ['A']
+}
+
+describe('DistanceMatrix', () => {
+  it('computes bfs distance and caches within limit', () => {
+    const dm = new DistanceMatrix(graph, 3)
+    expect(dm.getDistance('A', 'C')).toBe(2)
+    expect(dm.matrix['A']['C']).toBe(2)
+    expect(Object.keys(dm.matrix).length).toBeLessThanOrEqual(3)
+  })
+
+  it('does not cache when limit exceeded', () => {
+    const dm = new DistanceMatrix(graph, 2)
+    dm.getDistance('A', 'B')
+    dm.getDistance('A', 'C')
+    expect(dm.matrix['A']['B']).toBe(1)
+    expect(dm.matrix['A']['C']).toBeUndefined()
+  })
+
+  it('returns undefined when nodes disconnected', () => {
+    const dm = new DistanceMatrix(graph, 3)
+    expect(dm.getDistance('A', 'Z')).toBeUndefined()
+  })
+})

--- a/src/distanceMatrix.ts
+++ b/src/distanceMatrix.ts
@@ -1,0 +1,52 @@
+export interface Adjacency {
+  [node: string]: string[]
+}
+
+export interface DistMatrix {
+  [src: string]: Record<string, number>
+}
+
+export class DistanceMatrix {
+  matrix: DistMatrix = {}
+  private nodes = new Set<string>()
+
+  constructor(private graph: Adjacency, private limit = 1000) {}
+
+  private store(a: string, b: string, d: number) {
+    if (!this.matrix[a]) this.matrix[a] = {}
+    if (!this.matrix[b]) this.matrix[b] = {}
+    this.matrix[a][b] = d
+    this.matrix[b][a] = d
+    this.nodes.add(a)
+    this.nodes.add(b)
+  }
+
+  private bfs(a: string, b: string): number | undefined {
+    if (a === b) return 0
+    const visited = new Set<string>([a])
+    const queue: Array<{ n: string; d: number }> = [{ n: a, d: 0 }]
+    while (queue.length) {
+      const { n, d } = queue.shift()!
+      for (const nbr of this.graph[n] || []) {
+        if (nbr === b) return d + 1
+        if (!visited.has(nbr)) {
+          visited.add(nbr)
+          queue.push({ n: nbr, d: d + 1 })
+        }
+      }
+    }
+    return undefined
+  }
+
+  getDistance(a: string, b: string): number | undefined {
+    const cached = this.matrix[a]?.[b]
+    if (cached !== undefined) return cached
+    const dist = this.bfs(a, b)
+    if (dist === undefined) return undefined
+    const newNodes = [a, b].filter((n) => !this.nodes.has(n))
+    if (this.nodes.size + newNodes.length <= this.limit) {
+      this.store(a, b, dist)
+    }
+    return dist
+  }
+}

--- a/src/fsrs.test.ts
+++ b/src/fsrs.test.ts
@@ -1,0 +1,27 @@
+import { gradeFromResponse, toFsrsRating } from './fsrs'
+import { Rating } from 'ts-fsrs'
+
+describe('gradeFromResponse', () => {
+  it('returns 1 for incorrect answer', () => {
+    expect(gradeFromResponse(false)).toBe(1)
+  })
+
+  it('maps rating buttons', () => {
+    expect(gradeFromResponse(true, 'again')).toBe(2)
+    expect(gradeFromResponse(true, 'hard')).toBe(3)
+    expect(gradeFromResponse(true, 'okay')).toBe(4)
+    expect(gradeFromResponse(true, 'easy')).toBe(5)
+    // default when missing rating
+    expect(gradeFromResponse(true)).toBe(4)
+  })
+})
+
+describe('toFsrsRating', () => {
+  it('converts grades to ts-fsrs Rating enum', () => {
+    expect(toFsrsRating(1)).toBe(Rating.Again)
+    expect(toFsrsRating(2)).toBe(Rating.Again)
+    expect(toFsrsRating(3)).toBe(Rating.Hard)
+    expect(toFsrsRating(4)).toBe(Rating.Good)
+    expect(toFsrsRating(5)).toBe(Rating.Easy)
+  })
+})

--- a/src/fsrs.ts
+++ b/src/fsrs.ts
@@ -1,0 +1,40 @@
+import { fsrs as createFSRS, Rating } from 'ts-fsrs'
+
+export const fsrs = createFSRS()
+
+export type UserRating = 'easy' | 'okay' | 'hard' | 'again'
+
+export function gradeFromResponse(correct: boolean, rating?: UserRating): number {
+  if (!correct) return 1
+  switch (rating) {
+    case 'again':
+      return 2
+    case 'hard':
+      return 3
+    case 'easy':
+      return 5
+    case 'okay':
+    default:
+      return 4
+  }
+}
+
+export function toFsrsRating(grade: number): Rating {
+  switch (grade) {
+    case 5:
+      return Rating.Easy
+    case 4:
+      return Rating.Good
+    case 3:
+      return Rating.Hard
+    case 2:
+    case 1:
+    default:
+      return Rating.Again
+  }
+}
+
+export function nextReview(card: Parameters<typeof fsrs.nextReview>[0], grade: number) {
+  const [next] = fsrs.nextReview(card, toFsrsRating(grade))
+  return next
+}

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -1,0 +1,14 @@
+import React, { createContext, useContext } from 'react';
+import strings from '../i18n/en.json';
+
+type Strings = typeof strings;
+
+const I18nContext = createContext<Strings>(strings);
+
+export const I18nProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <I18nContext.Provider value={strings}>{children}</I18nContext.Provider>
+);
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,7 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+body.dark {
+  background-color: #000;
+  color: #fff;
+}

--- a/src/loaders.test.ts
+++ b/src/loaders.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { loadMarkdown, loadYaml } from './loaders'
+
+function mockFetch(status: number, body: string) {
+  return vi.fn().mockResolvedValue({ ok: status >= 200 && status < 300, text: () => Promise.resolve(body) })
+}
+
+describe('loadMarkdown/loadYaml', () => {
+  it('returns file contents on success', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, 'ok'))
+    await expect(loadMarkdown('/path')).resolves.toBe('ok')
+    await expect(loadYaml('/path')).resolves.toBe('ok')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns placeholder when fetch fails', async () => {
+    vi.stubGlobal('fetch', mockFetch(404, ''))
+    await expect(loadMarkdown('/missing')).resolves.toBe('Content unavailable')
+    await expect(loadYaml('/missing')).resolves.toBe('Content unavailable')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns placeholder on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')))
+    await expect(loadMarkdown('/err')).resolves.toBe('Content unavailable')
+    await expect(loadYaml('/err')).resolves.toBe('Content unavailable')
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,0 +1,19 @@
+export async function loadMarkdown(path: string): Promise<string> {
+  try {
+    const res = await fetch(path)
+    if (!res.ok) return 'Content unavailable'
+    return await res.text()
+  } catch {
+    return 'Content unavailable'
+  }
+}
+
+export async function loadYaml(path: string): Promise<string> {
+  try {
+    const res = await fetch(path)
+    if (!res.ok) return 'Content unavailable'
+    return await res.text()
+  } catch {
+    return 'Content unavailable'
+  }
+}

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,47 @@
+import { logError, logDebug } from './logger'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(tmpdir(), 'logs-'))
+  process.env.LOG_DIR = dir
+  process.env.LOG_MAX_SIZE = '50'
+})
+
+afterEach(async () => {
+  delete process.env.LOG_DIR
+  delete process.env.LOG_MAX_SIZE
+  delete process.env.NODE_ENV
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('logError', () => {
+  it('writes message and rotates when size exceeded', async () => {
+    await logError('first')
+    await logError('second message that is long enough to exceed limit')
+    const files = await fs.readdir(dir)
+    expect(files.sort()).toEqual(['error.log', 'error.log.1'])
+    const rot = await fs.readFile(path.join(dir, 'error.log.1'), 'utf8')
+    expect(rot.trim()).toBe('first')
+  })
+})
+
+describe('logDebug', () => {
+  it('skips in production mode', async () => {
+    process.env.NODE_ENV = 'production'
+    await logDebug('skip')
+    const files = await fs.readdir(dir)
+    expect(files).toEqual([])
+  })
+
+  it('writes in dev mode', async () => {
+    process.env.NODE_ENV = 'development'
+    await logDebug('hello')
+    const txt = await fs.readFile(path.join(dir, 'debug.log'), 'utf8')
+    expect(txt.trim()).toBe('hello')
+  })
+})

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const ROTATIONS = 3
+
+function logDir() {
+  return process.env.LOG_DIR || path.join(process.cwd(), 'logs')
+}
+
+function maxSize() {
+  return Number(process.env.LOG_MAX_SIZE) || 5 * 1024 * 1024
+}
+
+async function ensureDir() {
+  await fs.mkdir(logDir(), { recursive: true })
+}
+
+async function rotate(file: string) {
+  try {
+    await fs.stat(file)
+  } catch {
+    return
+  }
+  for (let i = ROTATIONS - 1; i >= 0; i--) {
+    const src = i === 0 ? file : `${file}.${i}`
+    try {
+      await fs.stat(src)
+    } catch {
+      continue
+    }
+    if (i + 1 >= ROTATIONS) {
+      await fs.unlink(src).catch(() => {})
+    } else {
+      await fs.rename(src, `${file}.${i + 1}`)
+    }
+  }
+}
+
+async function append(file: string, msg: string) {
+  await ensureDir()
+  let stat
+  try {
+    stat = await fs.stat(file)
+  } catch {}
+  const newSize = (stat?.size ?? 0) + Buffer.byteLength(msg + '\n')
+  if (stat && newSize > maxSize()) await rotate(file)
+  await fs.appendFile(file, msg + '\n')
+}
+
+export async function logError(msg: string) {
+  await append(path.join(logDir(), 'error.log'), msg)
+}
+
+export async function logDebug(msg: string) {
+  if (process.env.NODE_ENV === 'production') return
+  await append(path.join(logDir(), 'debug.log'), msg)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
+import { I18nProvider } from './i18n.tsx';
+import { ThemeProvider } from './theme.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <I18nProvider>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </I18nProvider>
   </StrictMode>,
-)
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App.tsx';
 import { I18nProvider } from './i18n.tsx';
 import { ThemeProvider } from './theme.tsx';
+import 'mathjax/es5/tex-mml-chtml.js';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -1,0 +1,27 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { atomicWriteFile, readJsonWithRecovery } from './persistence'
+
+/**
+ * Load a JSON file and migrate it to the expected format if needed.
+ * Migration scripts live in ../migrations/migrate_<from>_<to>.ts and
+ * export a default function taking the old data and returning the new.
+ * The original file is moved to backup_YYYYMMDD/ before writing the migrated data.
+ */
+export async function loadWithMigrations<T>(file: string, expectedFormat: string): Promise<T> {
+  let data = await readJsonWithRecovery<any>(file)
+  if (data.format === expectedFormat) {
+    return data as T
+  }
+  const migrationName = `migrate_${data.format}_${expectedFormat}.ts`
+  const migrationPath = path.resolve(__dirname, '..', 'migrations', migrationName)
+  const { default: migrate } = await import(pathToFileURL(migrationPath).href)
+  const migrated = await migrate(data)
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+  const backupDir = path.join(path.dirname(file), `backup_${date}`)
+  await fs.mkdir(backupDir, { recursive: true })
+  await fs.rename(file, path.join(backupDir, path.basename(file)))
+  await atomicWriteFile(file, JSON.stringify(migrated, null, 2))
+  return migrated as T
+}

--- a/src/mixedQuiz.test.ts
+++ b/src/mixedQuiz.test.ts
@@ -1,0 +1,50 @@
+import { assembleMixedQuiz, QuestionPool } from './mixedQuiz'
+import { MasteryEntry } from './updateMastery'
+import { XpLog } from './awardXp'
+import { describe, it, expect } from 'vitest'
+
+function entry(status: 'unseen' | 'in_progress' | 'mastered', due: string, idx = 0): MasteryEntry {
+  return { status, s: 0, d: 0, r: 0, l: 0, next_due: due, next_q_index: idx }
+}
+
+const pools: Record<string, QuestionPool> = {
+  A: { pool: ['a1', 'a2', 'a3'] },
+  B: { pool: ['b1', 'b2'] },
+  C: { pool: ['c1'] },
+}
+
+const xp: XpLog = {
+  format: 'XP-v1',
+  log: [
+    { id: 1, ts: '2025-01-10T00:00:00Z', delta: 10, source: 'A_q1' },
+    { id: 2, ts: '2025-01-10T00:05:00Z', delta: 10, source: 'B_q1' },
+    { id: 3, ts: '2024-12-01T00:00:00Z', delta: 10, source: 'C_q1' },
+  ],
+}
+
+const now = new Date('2025-01-30T00:00:00Z')
+
+describe('assembleMixedQuiz', () => {
+  it('filters by mastery status and last attempt', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('mastered', '2025-01-20T00:00:00Z'),
+      B: entry('in_progress', '2025-01-20T00:00:00Z'),
+      C: entry('mastered', '2024-12-20T00:00:00Z'),
+    }
+    const quiz = assembleMixedQuiz(mastery, pools, xp, 5, now)
+    expect(quiz.every(q => q.asId === 'A')).toBe(true)
+  })
+
+  it('cycles question indices by weight', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('mastered', '2025-01-28T00:00:00Z', 0), // overdue 2 -> weight 2
+      B: entry('mastered', '2025-01-29T00:00:00Z', 1), // overdue 1 -> weight 1
+    }
+    const quiz = assembleMixedQuiz(mastery, pools, xp, 3, now)
+    expect(quiz).toEqual([
+      { asId: 'A', qIndex: 0 },
+      { asId: 'B', qIndex: 1 },
+      { asId: 'A', qIndex: 1 },
+    ])
+  })
+})

--- a/src/mixedQuiz.ts
+++ b/src/mixedQuiz.ts
@@ -1,0 +1,61 @@
+export interface QuestionPool {
+  pool: any[]
+}
+
+export interface MixedQuestion {
+  asId: string
+  qIndex: number
+}
+
+import { MasteryEntry } from './updateMastery'
+import { XpLog } from './awardXp'
+import { advanceIdx } from './advanceIdx'
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((a.getTime() - b.getTime()) / 86400_000)
+}
+
+function lastAttemptTime(asId: string, xp: XpLog): Date | undefined {
+  for (let i = xp.log.length - 1; i >= 0; i--) {
+    const entry = xp.log[i]
+    if (entry.source.startsWith(asId)) {
+      return new Date(entry.ts)
+    }
+  }
+}
+
+export function assembleMixedQuiz(
+  mastery: Record<string, MasteryEntry>,
+  pools: Record<string, QuestionPool>,
+  xp: XpLog,
+  count = 15,
+  now: Date = new Date()
+): MixedQuestion[] {
+  const eligible: { id: string; weight: number; idx: number; total: number }[] = []
+  for (const [id, pool] of Object.entries(pools)) {
+    const m = mastery[id]
+    if (!m || m.status !== 'mastered') continue
+    const last = lastAttemptTime(id, xp)
+    if (!last || daysBetween(now, last) > 30) continue
+    const overdue = daysBetween(now, new Date(m.next_due))
+    const weight = Math.max(overdue, 0)
+    if (weight <= 0) continue
+    eligible.push({ id, weight, idx: m.next_q_index, total: pool.pool.length })
+  }
+  eligible.sort((a, b) => a.id.localeCompare(b.id))
+  const result: MixedQuestion[] = []
+  let remaining = true
+  while (result.length < count && remaining) {
+    remaining = false
+    for (const e of eligible) {
+      if (result.length >= count) break
+      if (e.weight > 0) {
+        result.push({ asId: e.id, qIndex: e.idx })
+        e.idx = advanceIdx(e.idx, e.total)
+        e.weight--
+        remaining = true
+      }
+    }
+  }
+  return result
+}

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,0 +1,34 @@
+import { atomicWriteFile, readJsonWithRecovery } from './persistence'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+async function makeTempDir() {
+  return await fs.mkdtemp(path.join(tmpdir(), 'persist-'))
+}
+
+describe('atomicWriteFile', () => {
+  it('writes and renames without tmp residue', async () => {
+    const dir = await makeTempDir()
+    const file = path.join(dir, 'prefs.json')
+    await atomicWriteFile(file, '{"a":1}')
+    const data = await fs.readFile(file, 'utf8')
+    expect(JSON.parse(data)).toEqual({ a: 1 })
+    const files = await fs.readdir(dir)
+    expect(files).toEqual(['prefs.json'])
+  })
+})
+
+describe('readJsonWithRecovery', () => {
+  it('recovers from leftover tmp file', async () => {
+    const dir = await makeTempDir()
+    const file = path.join(dir, 'prefs.json')
+    const tmp = file + '.tmp'
+    await fs.writeFile(tmp, '{"b":2}')
+    const data = await readJsonWithRecovery<any>(file)
+    expect(data).toEqual({ b: 2 })
+    const files = await fs.readdir(dir)
+    expect(files).toEqual(['prefs.json'])
+  })
+})

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,0 +1,29 @@
+import { promises as fs } from 'fs'
+import { existsSync } from 'fs'
+
+/**
+ * Atomically write data to a file using a temporary .tmp file then rename.
+ */
+export async function atomicWriteFile(path: string, data: string | Buffer): Promise<void> {
+  const tmp = path + '.tmp'
+  const handle = await fs.open(tmp, 'w')
+  try {
+    await handle.writeFile(data)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  await fs.rename(tmp, path)
+}
+
+/**
+ * Read a JSON file, recovering from a leftover .tmp if present.
+ */
+export async function readJsonWithRecovery<T>(path: string): Promise<T> {
+  const tmp = path + '.tmp'
+  if (existsSync(tmp) && !existsSync(path)) {
+    await fs.rename(tmp, path)
+  }
+  const text = await fs.readFile(path, 'utf8')
+  return JSON.parse(text) as T
+}

--- a/src/saveManager.test.ts
+++ b/src/saveManager.test.ts
@@ -1,0 +1,124 @@
+import { SaveManager } from './saveManager'
+import { awardXpAndSave } from './awardXp'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { describe, it, expect, vi } from 'vitest'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+function sampleState() {
+  return {
+    mastery: { format: 'Mastery-v2', ass: {}, topics: {} },
+    attempts: { format: 'Attempts-v1', ass: {}, topics: {} },
+    xp: { format: 'XP-v1', log: [] },
+    prefs: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+  }
+}
+
+describe('SaveManager', () => {
+  it('loads and autosaves state', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.load()
+    await awardXpAndSave(manager, 5, 'test', new Date('2025-01-01T00:00:00Z'))
+
+    const files = (await fs.readdir(dir)).sort()
+    expect(files).toEqual(['attempt_window.json', 'mastery.json', 'prefs.json', 'xp.json'])
+    const xp = JSON.parse(await fs.readFile(path.join(dir, 'xp.json'), 'utf8'))
+    expect(xp.log.length).toBe(1)
+    expect(xp.log[0].delta).toBe(5)
+  })
+
+  it('migrates older prefs file', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    const oldPrefs = { format: 'Prefs-v0', xp_since_mixed_quiz: 0, last_as: null }
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(oldPrefs))
+
+    const manager = new SaveManager(dir)
+    const now = new Date('2025-01-01T00:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    await manager.load()
+    vi.useRealTimers()
+
+    expect(manager.prefs).toEqual({ format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' })
+    const backupDir = path.join(dir, 'backup_20250101')
+    const backups = await fs.readdir(backupDir)
+    expect(backups).toContain('prefs.json')
+  })
+
+  it('exports and imports progress', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.load()
+
+    const zipPath = path.join(dir, 'export.zip')
+    await manager.exportProgress(zipPath)
+
+    const dir2 = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const manager2 = new SaveManager(dir2)
+    await manager2.importProgress(zipPath)
+
+    for (const f of ['mastery.json', 'attempt_window.json', 'xp.json', 'prefs.json']) {
+      const a = await fs.readFile(path.join(dir, f), 'utf8')
+      const b = await fs.readFile(path.join(dir2, f), 'utf8')
+      expect(b).toBe(a)
+    }
+  })
+
+  it('rejects import when format newer', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(tmpdir(), 'bundle-'))
+    const files = sampleState()
+    await fs.writeFile(path.join(tmpDir, 'mastery.json'), JSON.stringify(files.mastery))
+    await fs.writeFile(path.join(tmpDir, 'attempt_window.json'), JSON.stringify(files.attempts))
+    await fs.writeFile(path.join(tmpDir, 'xp.json'), JSON.stringify(files.xp))
+    await fs.writeFile(path.join(tmpDir, 'prefs.json'), JSON.stringify({ format: 'Prefs-v99' }))
+    const zipPath = path.join(tmpDir, 'bundle.zip')
+    await execFileAsync('zip', ['-q', '-j', zipPath, 'mastery.json', 'attempt_window.json', 'xp.json', 'prefs.json'], { cwd: tmpDir })
+
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const manager = new SaveManager(dir)
+    await expect(manager.importProgress(zipPath)).rejects.toThrow()
+  })
+
+  it('resetProfile archives and seeds blanks', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.resetProfile()
+
+    const parent = path.dirname(dir)
+    const archives = await fs.readdir(path.join(parent, 'archive'))
+    expect(archives.length).toBeGreaterThanOrEqual(1)
+
+    const files = (await fs.readdir(dir)).sort()
+    expect(files).toEqual(['attempt_window.json', 'mastery.json', 'prefs.json', 'xp.json'])
+    const mastery = JSON.parse(await fs.readFile(path.join(dir, 'mastery.json'), 'utf8'))
+    expect(mastery.ass).toEqual({})
+  })
+})
+

--- a/src/saveManager.ts
+++ b/src/saveManager.ts
@@ -1,0 +1,157 @@
+import path from 'path'
+import { promises as fs } from 'fs'
+import { atomicWriteFile } from './persistence'
+import { loadWithMigrations } from './migrations'
+import { Prefs, XpLog } from './awardXp'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { tmpdir } from 'os'
+
+export interface MasteryFile {
+  format: string
+  ass: Record<string, unknown>
+  topics: Record<string, any>
+}
+
+export interface AttemptsFile {
+  format: string
+  ass: Record<string, unknown>
+  topics: Record<string, unknown>
+}
+
+export interface SaveState {
+  mastery: MasteryFile
+  attempts: AttemptsFile
+  xp: XpLog
+  prefs: Prefs
+}
+
+export interface SaveManagerOptions {
+  toast?: (msg: string) => void
+  initialDelayMs?: number
+  maxDelayMs?: number
+}
+
+export class SaveManager implements SaveState {
+  mastery!: MasteryFile
+  attempts!: AttemptsFile
+  xp!: XpLog
+  prefs!: Prefs
+
+  private consecutiveFails = 0
+  private options: SaveManagerOptions
+
+  constructor(public dir: string, options: SaveManagerOptions = {}) {
+    this.options = options
+  }
+
+  private seedBlank() {
+    this.mastery = { format: 'Mastery-v2', ass: {}, topics: {} }
+    this.attempts = { format: 'Attempts-v1', ass: {}, topics: {} }
+    this.xp = { format: 'XP-v1', log: [] }
+    this.prefs = {
+      format: 'Prefs-v2',
+      profile: path.basename(this.dir),
+      xp_since_mixed_quiz: 0,
+      last_as: null,
+      ui_theme: 'default'
+    }
+  }
+
+  private static execFile = promisify(execFile)
+
+  private static versionGt(a: string, b: string): boolean {
+    const get = (v: string) => {
+      const m = v.match(/v(\d+)/)
+      return m ? parseInt(m[1]) : 0
+    }
+    return get(a) > get(b)
+  }
+
+  async load() {
+    this.mastery = await loadWithMigrations<MasteryFile>(path.join(this.dir, 'mastery.json'), 'Mastery-v2')
+    this.attempts = await loadWithMigrations<AttemptsFile>(path.join(this.dir, 'attempt_window.json'), 'Attempts-v1')
+    this.xp = await loadWithMigrations<XpLog>(path.join(this.dir, 'xp.json'), 'XP-v1')
+    this.prefs = await loadWithMigrations<Prefs>(path.join(this.dir, 'prefs.json'), 'Prefs-v2')
+  }
+
+  private async writeAll() {
+    await fs.mkdir(this.dir, { recursive: true })
+    await Promise.all([
+      atomicWriteFile(path.join(this.dir, 'mastery.json'), JSON.stringify(this.mastery, null, 2)),
+      atomicWriteFile(path.join(this.dir, 'attempt_window.json'), JSON.stringify(this.attempts, null, 2)),
+      atomicWriteFile(path.join(this.dir, 'xp.json'), JSON.stringify(this.xp, null, 2)),
+      atomicWriteFile(path.join(this.dir, 'prefs.json'), JSON.stringify(this.prefs, null, 2)),
+    ])
+  }
+
+  async autosave() {
+    let delay = this.options.initialDelayMs ?? 100
+    const maxDelay = this.options.maxDelayMs ?? 32000
+    while (true) {
+      try {
+        await this.writeAll()
+        this.consecutiveFails = 0
+        return
+      } catch (err) {
+        this.consecutiveFails++
+        if (this.consecutiveFails >= 3 && this.options.toast) {
+          this.options.toast('Autosave failed')
+        }
+        await new Promise((res) => setTimeout(res, delay))
+        delay = Math.min(delay * 2, maxDelay)
+      }
+    }
+  }
+
+  async exportProgress(outFile: string) {
+    await SaveManager.execFile('zip', [
+      '-q',
+      '-j',
+      outFile,
+      'mastery.json',
+      'attempt_window.json',
+      'xp.json',
+      'prefs.json',
+    ], { cwd: this.dir })
+  }
+
+  async importProgress(zipFile: string) {
+    const tmp = await fs.mkdtemp(path.join(tmpdir(), 'import-'))
+    await SaveManager.execFile('unzip', ['-qq', zipFile, '-d', tmp])
+
+    const files = {
+      mastery: 'Mastery-v2',
+      attempt_window: 'Attempts-v1',
+      xp: 'XP-v1',
+      prefs: 'Prefs-v2',
+    }
+
+    for (const [name, fmt] of Object.entries(files)) {
+      const p = path.join(tmp, `${name}.json`)
+      const data = JSON.parse(await fs.readFile(p, 'utf8'))
+      if (SaveManager.versionGt(data.format, fmt)) {
+        throw new Error('Unsupported format')
+      }
+    }
+
+    await fs.mkdir(this.dir, { recursive: true })
+    for (const name of Object.keys(files)) {
+      await fs.copyFile(path.join(tmp, `${name}.json`), path.join(this.dir, `${name}.json`))
+    }
+  }
+
+  async resetProfile() {
+    const ts = new Date().toISOString().replace(/[-:]/g, '').slice(0, 15)
+    const archiveRoot = path.join(path.dirname(this.dir), 'archive')
+    await fs.mkdir(archiveRoot, { recursive: true })
+    const dest = path.join(archiveRoot, ts)
+    if (await fs.stat(this.dir).catch(() => false)) {
+      await fs.rename(this.dir, dest)
+    }
+    await fs.mkdir(this.dir, { recursive: true })
+    this.seedBlank()
+    await this.writeAll()
+  }
+}
+

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { generateCandidates, DistMatrix, SkillMeta } from './scheduler'
+import { MasteryEntry } from './updateMastery'
+import { Prefs, XpLog } from './awardXp'
+
+function entry(status: 'unseen' | 'in_progress' | 'mastered', due: string): MasteryEntry {
+  return { status, s: 0, d: 0, r: 0, l: 0, next_due: due, next_q_index: 0 }
+}
+
+const skills: Record<string, SkillMeta> = {
+  A: { id: "A", topic: "T0", prereqs: ["P"] },
+  P: { id: 'P', topic: 'T0' }
+}
+
+const dist: DistMatrix = { P: { A: 2 } }
+
+const xp: XpLog = { format: 'XP-v1', log: [{ id: 1, ts: '2025-01-10T00:00:00Z', delta: 10, source: 'P_q1' }] }
+
+const prefs: Prefs = { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: 'P', ui_theme: 'default' }
+
+const now = new Date('2025-01-10T00:05:00Z')
+
+describe('generateCandidates', () => {
+  it('prioritizes overdue review with bonuses', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('in_progress', '2025-01-07T00:00:00Z'),
+      P: entry('in_progress', '2025-01-08T00:00:00Z')
+    }
+    const cand = generateCandidates(skills, mastery, { ...prefs, last_as: "P" }, { format: "XP-v1", log: [{ id: 1, ts: "2025-01-09T23:40:00Z", delta: 10, source: "P_q1" }] }, dist, now)
+    expect(cand[0]).toEqual({ id: 'A', kind: 'review', priority: 5 + 3 + 3 + 2 })
+  })
+
+  it('includes new skills when prereqs mastered', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('unseen', '2025-01-15T00:00:00Z'),
+      P: entry('mastered', '2025-01-01T00:00:00Z')
+    }
+    const cand = generateCandidates(skills, mastery, { ...prefs, last_as: null }, xp, dist, now)
+    expect(cand.some(c => c.id === "A" && c.kind === "new_as")).toBe(true)
+  })
+
+  it('omits candidate when non-interference gap not elapsed', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      P: entry('in_progress', '2025-01-08T00:00:00Z'),
+      A: entry('in_progress', '2025-01-07T00:00:00Z')
+    }
+    const recentXp: XpLog = { format: 'XP-v1', log: [{ id: 1, ts: '2025-01-10T00:04:00Z', delta: 10, source: 'P_q1' }] }
+    const cand = generateCandidates(skills, mastery, { ...prefs, last_as: 'P' }, recentXp, dist, now)
+    expect(cand.length).toBe(0)
+  })
+
+  it('adds mixed quiz when xp threshold met', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('unseen', '2025-01-15T00:00:00Z'),
+      P: entry('mastered', '2025-01-01T00:00:00Z')
+    }
+    const cand = generateCandidates(skills, mastery, { ...prefs, xp_since_mixed_quiz: 200 }, xp, dist, now)
+    const mq = cand.find(c => c.kind === 'mixed_quiz')
+    expect(mq).toBeDefined()
+  })
+})

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,102 @@
+import { prerequisitesMastered } from './unlock'
+import { Prefs, XpLog } from './awardXp'
+import { MasteryEntry } from './updateMastery'
+
+export interface SkillMeta {
+  id: string
+  topic: string
+  prereqs?: string[]
+}
+
+export interface DistMatrix {
+  [src: string]: Record<string, number>
+}
+
+export interface Candidate {
+  id: string
+  kind: 'review' | 'new_as' | 'mixed_quiz'
+  priority: number
+}
+
+const REVIEW_GAP_MIN_M = 10
+const MIXED_QUIZ_TRIGGER_XP = 150
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((a.getTime() - b.getTime()) / 86400_000)
+}
+
+function distanceBonus(last: string | null, target: string, dist: DistMatrix): number {
+  if (!last) return 5
+  const d = dist[last]?.[target]
+  if (d === undefined) return 5
+  return Math.min(5, d)
+}
+
+function lastAttemptTime(asId: string, xp: XpLog): Date | undefined {
+  for (let i = xp.log.length - 1; i >= 0; i--) {
+    const entry = xp.log[i]
+    if (entry.source.startsWith(asId)) {
+      return new Date(entry.ts)
+    }
+  }
+}
+
+function shouldRejectForGap(
+  skills: Record<string, SkillMeta>,
+  candidate: SkillMeta,
+  prefs: Prefs,
+  xp: XpLog,
+  now: Date,
+): boolean {
+  const lastId = prefs.last_as
+  if (!lastId) return false
+  const lastSkill = skills[lastId]
+  if (!lastSkill) return false
+  if (lastSkill.topic !== candidate.topic) return false
+  const lastTime = lastAttemptTime(lastId, xp)
+  if (!lastTime) return false
+  return (now.getTime() - lastTime.getTime()) / 60000 < REVIEW_GAP_MIN_M
+}
+
+export function generateCandidates(
+  skills: Record<string, SkillMeta>,
+  mastery: Record<string, MasteryEntry>,
+  prefs: Prefs,
+  xp: XpLog,
+  dist: DistMatrix,
+  now: Date = new Date(),
+): Candidate[] {
+  const list: Candidate[] = []
+  for (const skill of Object.values(skills)) {
+    const m = mastery[skill.id]
+    if (!m) continue
+    if (shouldRejectForGap(skills, skill, prefs, xp, now)) continue
+
+    const due = new Date(m.next_due)
+    const overdueDays = daysBetween(now, due)
+    if (m.status !== 'unseen' && overdueDays >= 0) {
+      const overdueBonus = Math.min(Math.max(overdueDays, 0), 5)
+      const overduePrereqs = skill.prereqs?.filter(p => {
+        const pm = mastery[p]
+        return pm && pm.status !== 'unseen' && new Date(pm.next_due) <= now
+      }).length ?? 0
+      const priority =
+        5 +
+        overdueBonus +
+        3 * overduePrereqs +
+        distanceBonus(prefs.last_as, skill.id, dist)
+      list.push({ id: skill.id, kind: 'review', priority })
+    } else if (m.status === 'unseen' && prerequisitesMastered(skill, mastery)) {
+      const priority =
+        3 +
+        0 +
+        0 +
+        distanceBonus(prefs.last_as, skill.id, dist)
+      list.push({ id: skill.id, kind: 'new_as', priority })
+    }
+  }
+  if (prefs.xp_since_mixed_quiz >= MIXED_QUIZ_TRIGGER_XP) {
+    list.push({ id: 'mixed_quiz', kind: 'mixed_quiz', priority: 2 })
+  }
+  return list.sort((a, b) => b.priority - a.priority)
+}

--- a/src/schemaValidation.test.ts
+++ b/src/schemaValidation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { readFile } from 'fs/promises'
+import path from 'path'
+import Ajv from 'ajv'
+import { load as loadYaml } from 'js-yaml'
+
+const ajv = new Ajv()
+
+async function loadJson(file: string) {
+  const txt = await readFile(file, 'utf8')
+  return JSON.parse(txt)
+}
+
+async function validate(schemaFile: string, dataFile: string, isYaml = false) {
+  const schema = await loadJson(schemaFile)
+  const validateFn = ajv.compile(schema)
+  const dataTxt = await readFile(dataFile, 'utf8')
+  const data = isYaml ? loadYaml(dataTxt) : JSON.parse(dataTxt)
+  const valid = validateFn(data)
+  if (!valid) console.error(validateFn.errors)
+  expect(valid).toBe(true)
+}
+
+describe('sample data matches JSON schemas', () => {
+  const root = process.cwd()
+  it('validates courses.json', async () => {
+    await validate(path.join(root, 'schema/courses-v1.json'), path.join(root, 'courses.json'))
+  })
+  it('validates catalog', async () => {
+    await validate(path.join(root, 'schema/catalog-v1.json'), path.join(root, 'course/ea/catalog.json'))
+  })
+  it('validates topics', async () => {
+    const schema = path.join(root, 'schema/topic-v1.json')
+    for (const f of ['T001.json','T002.json']) {
+      await validate(schema, path.join(root, 'course/ea/topics', f))
+    }
+  })
+  it('validates skills', async () => {
+    const schema = path.join(root, 'schema/skill-v1.json')
+    for (const num of ['001','003','004','013']) {
+      const f = `A${'S'}${num}.json`
+      await validate(schema, path.join(root, 'course/ea/skills', f))
+    }
+  })
+  it('validates question YAML', async () => {
+    const schema = path.join(root, 'schema/asq-v1.json')
+    for (const num of ['001','003','004','013']) {
+      const f = `A${'S'}${num}.yaml`
+      await validate(schema, path.join(root, 'course/ea/as_questions', f), true)
+    }
+  })
+  it('validates save files', async () => {
+    await validate(path.join(root, 'schema/mastery-v2.json'), path.join(root, 'save/mastery.json'))
+    await validate(path.join(root, 'schema/attempts-v1.json'), path.join(root, 'save/attempt_window.json'))
+    await validate(path.join(root, 'schema/xp-v1.json'), path.join(root, 'save/xp.json'))
+    await validate(path.join(root, 'schema/prefs-v2.json'), path.join(root, 'save/prefs.json'))
+  })
+})

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Dashboard</h2>
+      <p>Welcome to Skill Mastery.</p>
+    </div>
+  );
+}

--- a/src/screens/Learning.tsx
+++ b/src/screens/Learning.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Learning() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Learning</h2>
+      <p>Start your next Skill here.</p>
+    </div>
+  );
+}

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Library() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Course Library</h2>
+      <p>Browse available courses.</p>
+    </div>
+  );
+}

--- a/src/screens/Progress.tsx
+++ b/src/screens/Progress.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Progress() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Progress Graph</h2>
+      <p>Track your Skill mastery.</p>
+    </div>
+  );
+}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Settings() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Settings</h2>
+      <p>Adjust your preferences.</p>
+    </div>
+  );
+}

--- a/src/screens/__tests__/navigation.e2e.test.tsx
+++ b/src/screens/__tests__/navigation.e2e.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../../App'
+import { I18nProvider } from '../../i18n'
+import { ThemeProvider } from '../../theme'
+
+describe('navigation between screens', () => {
+  function setup() {
+    render(
+      <I18nProvider>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </I18nProvider>
+    )
+  }
+
+  it('navigates through all tabs', () => {
+    setup()
+    // starts on Home
+    expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /learning/i }))
+    expect(screen.getByRole('heading', { name: /learning/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /progress/i }))
+    expect(screen.getByRole('heading', { name: /progress graph/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /library/i }))
+    expect(screen.getByRole('heading', { name: /course library/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
+  })
+})

--- a/src/screens/__tests__/screenHeadings.test.tsx
+++ b/src/screens/__tests__/screenHeadings.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import Home from '../Home'
+import Learning from '../Learning'
+import Progress from '../Progress'
+import Library from '../Library'
+import Settings from '../Settings'
+
+describe('screen headings match mockup', () => {
+  it('home screen shows Dashboard heading', () => {
+    render(<Home />)
+    expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
+  })
+
+  it('learning screen shows Learning heading', () => {
+    render(<Learning />)
+    expect(screen.getByRole('heading', { name: /learning/i })).toBeInTheDocument()
+  })
+
+  it('progress screen shows Progress Graph heading', () => {
+    render(<Progress />)
+    expect(screen.getByRole('heading', { name: /progress graph/i })).toBeInTheDocument()
+  })
+
+  it('library screen shows Course Library heading', () => {
+    render(<Library />)
+    expect(screen.getByRole('heading', { name: /course library/i })).toBeInTheDocument()
+  })
+
+  it('settings screen shows Settings heading', () => {
+    render(<Settings />)
+    expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
+  })
+})

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'; 

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'default' | 'dark';
+
+interface ThemeState {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeState>({
+  theme: 'default',
+  toggle: () => {},
+});
+
+export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('default');
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  const toggle = () => setTheme(t => (t === 'dark' ? 'default' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/unlock.test.ts
+++ b/src/unlock.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { prerequisitesMastered, SkillData, MasteryEntry } from './unlock'
+
+describe('prerequisitesMastered', () => {
+  const mastery: Record<string, MasteryEntry> = {
+    s1: { status: 'mastered' },
+    s2: { status: 'mastered' },
+    s3: { status: 'in_progress' },
+  }
+
+  it('returns true when no prereqs', () => {
+    const skill: SkillData = { id: 'A', name: 'A' }
+    expect(prerequisitesMastered(skill, mastery)).toBe(true)
+  })
+
+  it('returns true when all prereqs mastered', () => {
+    const skill: SkillData = { id: 'B', name: 'B', prereqs: ['s1', 's2'] }
+    expect(prerequisitesMastered(skill, mastery)).toBe(true)
+  })
+
+  it('returns false when any prereq not mastered', () => {
+    const skill: SkillData = { id: 'C', name: 'C', prereqs: ['s1', 's3'] }
+    expect(prerequisitesMastered(skill, mastery)).toBe(false)
+  })
+
+  it('returns false when mastery entry missing', () => {
+    const skill: SkillData = { id: 'D', name: 'D', prereqs: ['s1', 's4'] }
+    expect(prerequisitesMastered(skill, mastery)).toBe(false)
+  })
+})

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -1,0 +1,22 @@
+export interface SkillData {
+  id: string
+  name: string
+  prereqs?: string[]
+  weights?: Record<string, number>
+}
+
+export interface MasteryEntry {
+  status: 'unseen' | 'in_progress' | 'mastered'
+  // other fields ignored
+}
+
+/**
+ * Return true if all prerequisites for this skill are mastered.
+ */
+export function prerequisitesMastered(
+  skill: SkillData,
+  mastery: Record<string, MasteryEntry | undefined>
+): boolean {
+  if (!skill.prereqs || skill.prereqs.length === 0) return true
+  return skill.prereqs.every((id) => mastery[id]?.status === 'mastered')
+}

--- a/src/updateMastery.test.ts
+++ b/src/updateMastery.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { updateMastery, MasteryEntry, SkillMeta } from './updateMastery'
+import * as fsrsMod from './fsrs'
+
+function makeEntry(): MasteryEntry {
+  return {
+    status: 'unseen',
+    s: 0,
+    d: 0,
+    r: 0,
+    l: 0,
+    next_due: '2025-01-01T00:00:00.000Z',
+    next_q_index: 0
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('updateMastery', () => {
+  it('updates main skill and increments question index', () => {
+    const mastery: Record<string, MasteryEntry> = { A: makeEntry() }
+    const skill: SkillMeta = { id: 'A', name: 'A' }
+
+    vi.spyOn(fsrsMod, 'nextReview').mockReturnValue({
+      stability: 0.5,
+      difficulty: 0.4,
+      reps: 1,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 1
+    } as any)
+
+    updateMastery(mastery, skill, 5, 5, new Date('2025-01-01T00:00:00Z'))
+
+    expect(mastery.A.s).toBe(0.5)
+    expect(mastery.A.next_q_index).toBe(1)
+    expect(mastery.A.next_due).toBe('2025-01-02T00:00:00.000Z')
+  })
+
+  it('applies implicit credit to prerequisites when grade>=4', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: makeEntry(),
+      P: makeEntry()
+    }
+    const skill: SkillMeta = { id: 'A', name: 'A', prereqs: ['P'], weights: { P: 0.5 } }
+
+    const mainNext = {
+      stability: 0.5,
+      difficulty: 0.4,
+      reps: 1,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 1
+    }
+    const prereqNext = {
+      stability: 0.9,
+      difficulty: 0.8,
+      reps: 2,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 4
+    }
+    const spy = vi.spyOn(fsrsMod, 'nextReview')
+    spy.mockReturnValueOnce(mainNext as any).mockReturnValueOnce(prereqNext as any)
+
+    updateMastery(mastery, skill, 5, 5, new Date('2025-01-01T00:00:00Z'))
+
+    // main updated
+    expect(mastery.A.s).toBe(0.5)
+    // prereq interval damped: 0.3 * 0.5 * 4 = 0.6 -> round ->1
+    expect(mastery.P.next_due).toBe('2025-01-02T00:00:00.000Z')
+    expect(mastery.P.s).toBe(0.9)
+  })
+
+  it('skips implicit credit when grade<4', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: makeEntry(),
+      P: makeEntry()
+    }
+    const skill: SkillMeta = { id: 'A', name: 'A', prereqs: ['P'] }
+
+    vi.spyOn(fsrsMod, 'nextReview').mockReturnValue({
+      stability: 0.5,
+      difficulty: 0.4,
+      reps: 1,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 2
+    } as any)
+
+    updateMastery(mastery, skill, 3, 5, new Date('2025-01-01T00:00:00Z'))
+
+    expect(mastery.P.next_due).toBe('2025-01-01T00:00:00.000Z')
+  })
+})

--- a/src/updateMastery.ts
+++ b/src/updateMastery.ts
@@ -1,0 +1,88 @@
+export interface MasteryEntry {
+  status: 'unseen' | 'in_progress' | 'mastered'
+  s: number
+  d: number
+  r: number
+  l: number
+  next_due: string
+  next_q_index: number
+}
+
+export interface SkillMeta {
+  id: string
+  name: string
+  prereqs?: string[]
+  weights?: Record<string, number>
+}
+
+import { nextReview } from './fsrs'
+import { advanceIdx } from './advanceIdx'
+
+const ALPHA_IMPLICIT = 0.3
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 86400_000)
+}
+
+function toCard(entry: MasteryEntry) {
+  return {
+    due: new Date(entry.next_due),
+    stability: entry.s,
+    difficulty: entry.d,
+    reps: entry.r,
+    lapses: entry.l,
+    elapsed_days: 0,
+    scheduled_days: 0,
+    learning_steps: 0,
+    state: 0
+  }
+}
+
+/**
+ * Update mastery state for an answered skill and apply implicit
+ * prerequisite credit when grade \u2265 4.
+ * Mutates the mastery record in place.
+ */
+export function updateMastery(
+  mastery: Record<string, MasteryEntry>,
+  skill: SkillMeta,
+  grade: number,
+  totalQuestions: number,
+  now: Date = new Date()
+): void {
+  const entry = mastery[skill.id]
+  if (!entry) return
+
+  const card = toCard(entry)
+  const next = nextReview(card, grade)
+
+  mastery[skill.id] = {
+    status: 'in_progress',
+    s: next.stability,
+    d: next.difficulty,
+    r: next.reps,
+    l: next.lapses,
+    next_due: next.due.toISOString(),
+    next_q_index: advanceIdx(entry.next_q_index, totalQuestions)
+  }
+
+  if (grade >= 4 && skill.prereqs) {
+    for (const p of skill.prereqs) {
+      const m = mastery[p]
+      if (!m) continue
+      const weight = skill.weights?.[p] ?? 1
+      const pNext = nextReview(toCard(m), 4)
+      const interval = pNext.scheduled_days
+      const damp = Math.max(1, Math.round(ALPHA_IMPLICIT * weight * interval))
+      mastery[p] = {
+        status: m.status,
+        s: pNext.stability,
+        d: pNext.difficulty,
+        r: pNext.reps,
+        l: pNext.lapses,
+        next_due: addDays(now, damp).toISOString(),
+        next_q_index: m.next_q_index
+      }
+    }
+  }
+}

--- a/src/useExternalLinks.test.tsx
+++ b/src/useExternalLinks.test.tsx
@@ -1,0 +1,16 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import useExternalLinks from './useExternalLinks';
+
+test('prompts before opening external link', () => {
+  const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  function Comp() {
+    useExternalLinks();
+    return <a href="https://example.com">ext</a>;
+  }
+  const { getByText } = render(<Comp />);
+  fireEvent.click(getByText('ext'));
+  expect(confirmSpy).toHaveBeenCalled();
+  expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank');
+});

--- a/src/useExternalLinks.tsx
+++ b/src/useExternalLinks.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+export default function useExternalLinks() {
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest('a');
+      if (anchor) {
+        const href = anchor.getAttribute('href');
+        if (href && /^https?:/i.test(href)) {
+          e.preventDefault();
+          if (window.confirm('Open in system browser?')) {
+            window.open(href, '_blank');
+          }
+        }
+      }
+    }
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, []);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true, // Optional: to make jest-dom matchers available globally
+    setupFiles: './src/setupTests.ts', // Optional: if you have a setup file
+  },
 })


### PR DESCRIPTION
## Summary
- implement basic i18n provider backed by `i18n/en.json`
- add theme context with dark mode toggle
- wrap app with new providers and hook up toggle button
- style dark mode via CSS
- validate i18n and prefs in test script
- remove completed TODO item

## Testing
- `npm test`