### PR TITLE
Implement CSP and Markdown renderer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,6 @@ file before committing.
 
 ## Packaging & Misc
 - [ ] Implement export/import of progress and course reset features.
-- [ ] Enforce CSP and sanitise Markdown with DOMPurify and MathJax rendering.
 - [ ] Add migration framework for save data format versions.
 # Additional tasks identified during comparison with docs/design_doc.md
 - [ ] Enforce topic unlock rule when all prerequisite topics are mastered.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+    <title>Skill Mastery App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/Markdown.test.tsx
+++ b/src/Markdown.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import Markdown from './Markdown'
+
+describe('Markdown sanitisation', () => {
+  it('removes script tags', () => {
+    render(<Markdown>{'hello <script>evil()</script>'}</Markdown>)
+    const div = screen.getByText('hello', { exact: false })
+    expect(div.innerHTML).not.toMatch(/script/)
+  })
+})

--- a/src/Markdown.tsx
+++ b/src/Markdown.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react'
+import DOMPurify from 'dompurify'
+
+export interface MarkdownProps {
+  children: string
+}
+
+// very small subset markdown -> html
+function mdToHtml(md: string): string {
+  let html = md
+    .replace(/^### (.*)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.*)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/\n\n+/g, '</p><p>')
+  return `<p>${html}</p>`
+}
+
+export default function Markdown({ children }: MarkdownProps) {
+  const sanitized = DOMPurify.sanitize(mdToHtml(children))
+
+  useEffect(() => {
+    // trigger MathJax typesetting if available
+    ;(window as any).MathJax?.typeset?.()
+  }, [sanitized])
+
+  return <div dangerouslySetInnerHTML={{ __html: sanitized }} />
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App.tsx';
 import { I18nProvider } from './i18n.tsx';
 import { ThemeProvider } from './theme.tsx';
+import 'mathjax/es5/tex-mml-chtml.js';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- enforce Content Security Policy meta tag
- render Markdown with DOMPurify sanitisation
- include MathJax for TeX support
- test Markdown sanitisation
- remove completed TODO

## Testing
- `npm test`