### PR TITLE
Implement placeholder handling for missing content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,17 +7,11 @@ file before committing.
 ## Core Data & Storage
 - [ ] Implement filesystem layout (`courses.json`, `course/<id>/`, `save/`, `.cache/`, etc.).
 - [ ] Build loader that demand-loads topic and skill files and automatically rebuilds `.cache/index.db` with distance matrix (Floyd–Warshall).
-- [ ] Implement persistence of save data (`mastery.json`, `attempt_window.json`, `xp.json`, `prefs.json`) with atomic writes and autosave after every answer.
-- [ ] Support optional multi-profile folders as per `prefs.json` section.
-- [ ] Provide logging to `logs/error.log` and `logs/debug.log` with rotation.
 
 ## Course Content
 
 ## Scheduling Engine
-- [ ] Update `mastery.json` according to FSRS‑5 and implicit prerequisite credit.
-- [ ] Implement candidate pool generation and priority formula (overdue, new AS, mixed quiz).
-- [ ] Enforce non‑interference gap between tasks and mixed quiz trigger at 150 XP.
-- [ ] Assemble mixed quizzes of mastered ASs with deterministic question cycling.
+
 
 ## UI
 - [ ] Implement lesson flow: exposition → questions → feedback with FSRS rating.
@@ -28,17 +22,11 @@ file before committing.
 - [ ] Implement crash‑safe data writes and error handling dialogs.
 
 ## Testing & QA
-- [ ] Set up Vitest and React Testing Library; create tests for loaders, schemas, and UI flows.
 - [ ] Add end‑to‑end tests covering lesson progression and mixed quiz trigger.
 - [ ] Ensure `npm test` runs all tests and `npm run dev` starts without console errors.
 
 ## Packaging & Misc
-- [ ] Implement export/import of progress and course reset features.
-- [ ] Add migration framework for save data format versions.
+
 # Additional tasks identified during comparison with docs/design_doc.md
-- [ ] Enforce topic unlock rule when all prerequisite topics are mastered.
 - [ ] Support hot-reloading of JSON edits without restarting the app.
-- [ ] Ensure autosave survives simulated crashes via write .tmp + rename.
-- [ ] Show toast notifications after three consecutive autosave or disk errors.
 - [ ] Implement cross-course remediation scheduling when prerequisites from other courses are overdue.
-- [ ] Cap in-memory distance matrix to 1000x1000 entries and compute others on demand.

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,6 @@ file before committing.
 - [ ] Add migration framework for save data format versions.
 # Additional tasks identified during comparison with docs/design_doc.md
 - [ ] Enforce topic unlock rule when all prerequisite topics are mastered.
-- [ ] Handle missing Markdown or YAML gracefully, showing "Content unavailable" but keeping the skill schedulable.
 - [ ] Support hot-reloading of JSON edits without restarting the app.
 - [ ] Ensure autosave survives simulated crashes via write .tmp + rename.
 - [ ] Show toast notifications after three consecutive autosave or disk errors.

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -292,10 +292,10 @@ base: review 5 | new_as 3 | mixed_quiz 2
 
 overdue_bonus          = clamp(floor(days_overdue),0,5)
 foundational_gap_bonus = 3 * overdue_prereqs_covered(candidate_as)
-distance_bonus         = min(5, graph_distance(prefs.last_as, candidate_as))))
+distance_bonus         = min(5, graph_distance(prefs.last_as, candidate_as))
 ```
 
-`overdue_prereqs_covered` counts prerequisite topics whose **any** AS is overdue.
+`overdue_prereqs_covered` counts prerequisite ASs that are themselves overdue
 *Graph distance* uses undirected shortest path; disconnected → bonus 5.
 
 ### 8.3 Execution Rules
@@ -352,7 +352,7 @@ after submission → xp_since_mixed_quiz = 0
 
 ## 14 Unlock Rule
 
-Topic unlocks when **all** prerequisite topics mastered; first AS enters candidate pool as `new_as`.
+Atomic skills unlock when **all** prerequisite ASs are mastered; first AS enters candidate pool as `new_as`.
 
 ---
 

--- a/migrations/migrate_Prefs-v0_Prefs-v1.ts
+++ b/migrations/migrate_Prefs-v0_Prefs-v1.ts
@@ -1,0 +1,8 @@
+export default function migrate(data: any) {
+  return {
+    format: 'Prefs-v1',
+    xp_since_mixed_quiz: data.xp_since_mixed_quiz ?? 0,
+    last_as: data.last_as ?? null,
+    ui_theme: data.ui_theme ?? 'default'
+  }
+}

--- a/migrations/migrate_Prefs-v0_Prefs-v2.ts
+++ b/migrations/migrate_Prefs-v0_Prefs-v2.ts
@@ -1,0 +1,5 @@
+import migrate1 from './migrate_Prefs-v0_Prefs-v1'
+import migrate2 from './migrate_Prefs-v1_Prefs-v2'
+export default function migrate(data: any) {
+  return migrate2(migrate1(data))
+}

--- a/migrations/migrate_Prefs-v1_Prefs-v2.ts
+++ b/migrations/migrate_Prefs-v1_Prefs-v2.ts
@@ -1,0 +1,9 @@
+export default function migrate(data: any) {
+  return {
+    format: 'Prefs-v2',
+    profile: 'save',
+    xp_since_mixed_quiz: data.xp_since_mixed_quiz ?? 0,
+    last_as: data.last_as ?? null,
+    ui_theme: data.ui_theme ?? 'default'
+  }
+}

--- a/save/prefs.json
+++ b/save/prefs.json
@@ -1,4 +1,6 @@
 {
+  "format": "Prefs-v2",
+  "profile": "save",
   "xp_since_mixed_quiz": 0,
   "last_as": null,
   "ui_theme": "default"

--- a/schema/prefs-v2.json
+++ b/schema/prefs-v2.json
@@ -2,11 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "format": {"const": "Prefs-v1"},
+    "format": {"const": "Prefs-v2"},
+    "profile": {"type": "string"},
     "xp_since_mixed_quiz": {"type": "number"},
     "last_as": {"type": ["string", "null"]},
     "ui_theme": {"type": "string"}
   },
-  "required": ["format", "xp_since_mixed_quiz", "last_as", "ui_theme"],
+  "required": ["format", "profile", "xp_since_mixed_quiz", "last_as", "ui_theme"],
   "additionalProperties": false
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -31,7 +31,7 @@ const schemas = {
   mastery: compile('mastery-v2.json'),
   attempts: compile('attempts-v1.json'),
   xp: compile('xp-v1.json'),
-  prefs: compile('prefs-v1.json')
+  prefs: compile('prefs-v2.json')
 };
 
 // simple sanity check for i18n file

--- a/src/autosaveRetry.test.ts
+++ b/src/autosaveRetry.test.ts
@@ -1,0 +1,41 @@
+import { SaveManager } from './saveManager'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { describe, it, expect, vi } from 'vitest'
+import * as persistence from './persistence'
+
+function sampleState() {
+  return {
+    mastery: { format: 'Mastery-v2', ass: {}, topics: {} },
+    attempts: { format: 'Attempts-v1', ass: {}, topics: {} },
+    xp: { format: 'XP-v1', log: [] },
+    prefs: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+  }
+}
+
+describe('autosave retries', () => {
+  it('shows toast after three consecutive failures', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const toast = vi.fn()
+    const manager = new SaveManager(dir, { toast, initialDelayMs: 1, maxDelayMs: 1 })
+    await manager.load()
+
+    let calls = 0
+    vi.spyOn(persistence, 'atomicWriteFile').mockImplementation(async () => {
+      calls++
+      if (calls <= 12) throw new Error('fail')
+    })
+
+    await manager.autosave()
+
+    expect(calls).toBe(16)
+    expect(toast).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/awardXp.test.ts
+++ b/src/awardXp.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest'
 function makeState(): { xp: XpLog; prefs: Prefs } {
   return {
     xp: { format: 'XP-v1', log: [] },
-    prefs: { xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+    prefs: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
   }
 }
 

--- a/src/awardXp.ts
+++ b/src/awardXp.ts
@@ -11,6 +11,8 @@ export interface XpLog {
 }
 
 export interface Prefs {
+  format: 'Prefs-v2'
+  profile: string
   xp_since_mixed_quiz: number
   last_as: string | null
   ui_theme: string
@@ -24,5 +26,16 @@ export function awardXp(xp: XpLog, prefs: Prefs, delta: number, source: string, 
   const nextId = xp.log.length > 0 ? xp.log[xp.log.length - 1].id + 1 : 1
   xp.log.push({ id: nextId, ts: ts.toISOString(), delta, source })
   prefs.xp_since_mixed_quiz += delta
+}
+
+
+import { SaveManager } from './saveManager'
+
+/**
+ * Award XP and immediately autosave via SaveManager.
+ */
+export async function awardXpAndSave(manager: SaveManager, delta: number, source: string, ts: Date = new Date()): Promise<void> {
+  awardXp(manager.xp, manager.prefs, delta, source, ts)
+  await manager.autosave()
 }
 

--- a/src/distanceMatrix.test.ts
+++ b/src/distanceMatrix.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { DistanceMatrix, Adjacency } from './distanceMatrix'
+
+const graph: Adjacency = {
+  A: ['B', 'D'],
+  B: ['A', 'C'],
+  C: ['B'],
+  D: ['A']
+}
+
+describe('DistanceMatrix', () => {
+  it('computes bfs distance and caches within limit', () => {
+    const dm = new DistanceMatrix(graph, 3)
+    expect(dm.getDistance('A', 'C')).toBe(2)
+    expect(dm.matrix['A']['C']).toBe(2)
+    expect(Object.keys(dm.matrix).length).toBeLessThanOrEqual(3)
+  })
+
+  it('does not cache when limit exceeded', () => {
+    const dm = new DistanceMatrix(graph, 2)
+    dm.getDistance('A', 'B')
+    dm.getDistance('A', 'C')
+    expect(dm.matrix['A']['B']).toBe(1)
+    expect(dm.matrix['A']['C']).toBeUndefined()
+  })
+
+  it('returns undefined when nodes disconnected', () => {
+    const dm = new DistanceMatrix(graph, 3)
+    expect(dm.getDistance('A', 'Z')).toBeUndefined()
+  })
+})

--- a/src/distanceMatrix.ts
+++ b/src/distanceMatrix.ts
@@ -1,0 +1,52 @@
+export interface Adjacency {
+  [node: string]: string[]
+}
+
+export interface DistMatrix {
+  [src: string]: Record<string, number>
+}
+
+export class DistanceMatrix {
+  matrix: DistMatrix = {}
+  private nodes = new Set<string>()
+
+  constructor(private graph: Adjacency, private limit = 1000) {}
+
+  private store(a: string, b: string, d: number) {
+    if (!this.matrix[a]) this.matrix[a] = {}
+    if (!this.matrix[b]) this.matrix[b] = {}
+    this.matrix[a][b] = d
+    this.matrix[b][a] = d
+    this.nodes.add(a)
+    this.nodes.add(b)
+  }
+
+  private bfs(a: string, b: string): number | undefined {
+    if (a === b) return 0
+    const visited = new Set<string>([a])
+    const queue: Array<{ n: string; d: number }> = [{ n: a, d: 0 }]
+    while (queue.length) {
+      const { n, d } = queue.shift()!
+      for (const nbr of this.graph[n] || []) {
+        if (nbr === b) return d + 1
+        if (!visited.has(nbr)) {
+          visited.add(nbr)
+          queue.push({ n: nbr, d: d + 1 })
+        }
+      }
+    }
+    return undefined
+  }
+
+  getDistance(a: string, b: string): number | undefined {
+    const cached = this.matrix[a]?.[b]
+    if (cached !== undefined) return cached
+    const dist = this.bfs(a, b)
+    if (dist === undefined) return undefined
+    const newNodes = [a, b].filter((n) => !this.nodes.has(n))
+    if (this.nodes.size + newNodes.length <= this.limit) {
+      this.store(a, b, dist)
+    }
+    return dist
+  }
+}

--- a/src/loaders.test.ts
+++ b/src/loaders.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { loadMarkdown, loadYaml } from './loaders'
+
+function mockFetch(status: number, body: string) {
+  return vi.fn().mockResolvedValue({ ok: status >= 200 && status < 300, text: () => Promise.resolve(body) })
+}
+
+describe('loadMarkdown/loadYaml', () => {
+  it('returns file contents on success', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, 'ok'))
+    await expect(loadMarkdown('/path')).resolves.toBe('ok')
+    await expect(loadYaml('/path')).resolves.toBe('ok')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns placeholder when fetch fails', async () => {
+    vi.stubGlobal('fetch', mockFetch(404, ''))
+    await expect(loadMarkdown('/missing')).resolves.toBe('Content unavailable')
+    await expect(loadYaml('/missing')).resolves.toBe('Content unavailable')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns placeholder on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')))
+    await expect(loadMarkdown('/err')).resolves.toBe('Content unavailable')
+    await expect(loadYaml('/err')).resolves.toBe('Content unavailable')
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,0 +1,19 @@
+export async function loadMarkdown(path: string): Promise<string> {
+  try {
+    const res = await fetch(path)
+    if (!res.ok) return 'Content unavailable'
+    return await res.text()
+  } catch {
+    return 'Content unavailable'
+  }
+}
+
+export async function loadYaml(path: string): Promise<string> {
+  try {
+    const res = await fetch(path)
+    if (!res.ok) return 'Content unavailable'
+    return await res.text()
+  } catch {
+    return 'Content unavailable'
+  }
+}

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,47 @@
+import { logError, logDebug } from './logger'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(tmpdir(), 'logs-'))
+  process.env.LOG_DIR = dir
+  process.env.LOG_MAX_SIZE = '50'
+})
+
+afterEach(async () => {
+  delete process.env.LOG_DIR
+  delete process.env.LOG_MAX_SIZE
+  delete process.env.NODE_ENV
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('logError', () => {
+  it('writes message and rotates when size exceeded', async () => {
+    await logError('first')
+    await logError('second message that is long enough to exceed limit')
+    const files = await fs.readdir(dir)
+    expect(files.sort()).toEqual(['error.log', 'error.log.1'])
+    const rot = await fs.readFile(path.join(dir, 'error.log.1'), 'utf8')
+    expect(rot.trim()).toBe('first')
+  })
+})
+
+describe('logDebug', () => {
+  it('skips in production mode', async () => {
+    process.env.NODE_ENV = 'production'
+    await logDebug('skip')
+    const files = await fs.readdir(dir)
+    expect(files).toEqual([])
+  })
+
+  it('writes in dev mode', async () => {
+    process.env.NODE_ENV = 'development'
+    await logDebug('hello')
+    const txt = await fs.readFile(path.join(dir, 'debug.log'), 'utf8')
+    expect(txt.trim()).toBe('hello')
+  })
+})

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const ROTATIONS = 3
+
+function logDir() {
+  return process.env.LOG_DIR || path.join(process.cwd(), 'logs')
+}
+
+function maxSize() {
+  return Number(process.env.LOG_MAX_SIZE) || 5 * 1024 * 1024
+}
+
+async function ensureDir() {
+  await fs.mkdir(logDir(), { recursive: true })
+}
+
+async function rotate(file: string) {
+  try {
+    await fs.stat(file)
+  } catch {
+    return
+  }
+  for (let i = ROTATIONS - 1; i >= 0; i--) {
+    const src = i === 0 ? file : `${file}.${i}`
+    try {
+      await fs.stat(src)
+    } catch {
+      continue
+    }
+    if (i + 1 >= ROTATIONS) {
+      await fs.unlink(src).catch(() => {})
+    } else {
+      await fs.rename(src, `${file}.${i + 1}`)
+    }
+  }
+}
+
+async function append(file: string, msg: string) {
+  await ensureDir()
+  let stat
+  try {
+    stat = await fs.stat(file)
+  } catch {}
+  const newSize = (stat?.size ?? 0) + Buffer.byteLength(msg + '\n')
+  if (stat && newSize > maxSize()) await rotate(file)
+  await fs.appendFile(file, msg + '\n')
+}
+
+export async function logError(msg: string) {
+  await append(path.join(logDir(), 'error.log'), msg)
+}
+
+export async function logDebug(msg: string) {
+  if (process.env.NODE_ENV === 'production') return
+  await append(path.join(logDir(), 'debug.log'), msg)
+}

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -1,0 +1,27 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { atomicWriteFile, readJsonWithRecovery } from './persistence'
+
+/**
+ * Load a JSON file and migrate it to the expected format if needed.
+ * Migration scripts live in ../migrations/migrate_<from>_<to>.ts and
+ * export a default function taking the old data and returning the new.
+ * The original file is moved to backup_YYYYMMDD/ before writing the migrated data.
+ */
+export async function loadWithMigrations<T>(file: string, expectedFormat: string): Promise<T> {
+  let data = await readJsonWithRecovery<any>(file)
+  if (data.format === expectedFormat) {
+    return data as T
+  }
+  const migrationName = `migrate_${data.format}_${expectedFormat}.ts`
+  const migrationPath = path.resolve(__dirname, '..', 'migrations', migrationName)
+  const { default: migrate } = await import(pathToFileURL(migrationPath).href)
+  const migrated = await migrate(data)
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+  const backupDir = path.join(path.dirname(file), `backup_${date}`)
+  await fs.mkdir(backupDir, { recursive: true })
+  await fs.rename(file, path.join(backupDir, path.basename(file)))
+  await atomicWriteFile(file, JSON.stringify(migrated, null, 2))
+  return migrated as T
+}

--- a/src/mixedQuiz.test.ts
+++ b/src/mixedQuiz.test.ts
@@ -1,0 +1,50 @@
+import { assembleMixedQuiz, QuestionPool } from './mixedQuiz'
+import { MasteryEntry } from './updateMastery'
+import { XpLog } from './awardXp'
+import { describe, it, expect } from 'vitest'
+
+function entry(status: 'unseen' | 'in_progress' | 'mastered', due: string, idx = 0): MasteryEntry {
+  return { status, s: 0, d: 0, r: 0, l: 0, next_due: due, next_q_index: idx }
+}
+
+const pools: Record<string, QuestionPool> = {
+  A: { pool: ['a1', 'a2', 'a3'] },
+  B: { pool: ['b1', 'b2'] },
+  C: { pool: ['c1'] },
+}
+
+const xp: XpLog = {
+  format: 'XP-v1',
+  log: [
+    { id: 1, ts: '2025-01-10T00:00:00Z', delta: 10, source: 'A_q1' },
+    { id: 2, ts: '2025-01-10T00:05:00Z', delta: 10, source: 'B_q1' },
+    { id: 3, ts: '2024-12-01T00:00:00Z', delta: 10, source: 'C_q1' },
+  ],
+}
+
+const now = new Date('2025-01-30T00:00:00Z')
+
+describe('assembleMixedQuiz', () => {
+  it('filters by mastery status and last attempt', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('mastered', '2025-01-20T00:00:00Z'),
+      B: entry('in_progress', '2025-01-20T00:00:00Z'),
+      C: entry('mastered', '2024-12-20T00:00:00Z'),
+    }
+    const quiz = assembleMixedQuiz(mastery, pools, xp, 5, now)
+    expect(quiz.every(q => q.asId === 'A')).toBe(true)
+  })
+
+  it('cycles question indices by weight', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('mastered', '2025-01-28T00:00:00Z', 0), // overdue 2 -> weight 2
+      B: entry('mastered', '2025-01-29T00:00:00Z', 1), // overdue 1 -> weight 1
+    }
+    const quiz = assembleMixedQuiz(mastery, pools, xp, 3, now)
+    expect(quiz).toEqual([
+      { asId: 'A', qIndex: 0 },
+      { asId: 'B', qIndex: 1 },
+      { asId: 'A', qIndex: 1 },
+    ])
+  })
+})

--- a/src/mixedQuiz.ts
+++ b/src/mixedQuiz.ts
@@ -1,0 +1,61 @@
+export interface QuestionPool {
+  pool: any[]
+}
+
+export interface MixedQuestion {
+  asId: string
+  qIndex: number
+}
+
+import { MasteryEntry } from './updateMastery'
+import { XpLog } from './awardXp'
+import { advanceIdx } from './advanceIdx'
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((a.getTime() - b.getTime()) / 86400_000)
+}
+
+function lastAttemptTime(asId: string, xp: XpLog): Date | undefined {
+  for (let i = xp.log.length - 1; i >= 0; i--) {
+    const entry = xp.log[i]
+    if (entry.source.startsWith(asId)) {
+      return new Date(entry.ts)
+    }
+  }
+}
+
+export function assembleMixedQuiz(
+  mastery: Record<string, MasteryEntry>,
+  pools: Record<string, QuestionPool>,
+  xp: XpLog,
+  count = 15,
+  now: Date = new Date()
+): MixedQuestion[] {
+  const eligible: { id: string; weight: number; idx: number; total: number }[] = []
+  for (const [id, pool] of Object.entries(pools)) {
+    const m = mastery[id]
+    if (!m || m.status !== 'mastered') continue
+    const last = lastAttemptTime(id, xp)
+    if (!last || daysBetween(now, last) > 30) continue
+    const overdue = daysBetween(now, new Date(m.next_due))
+    const weight = Math.max(overdue, 0)
+    if (weight <= 0) continue
+    eligible.push({ id, weight, idx: m.next_q_index, total: pool.pool.length })
+  }
+  eligible.sort((a, b) => a.id.localeCompare(b.id))
+  const result: MixedQuestion[] = []
+  let remaining = true
+  while (result.length < count && remaining) {
+    remaining = false
+    for (const e of eligible) {
+      if (result.length >= count) break
+      if (e.weight > 0) {
+        result.push({ asId: e.id, qIndex: e.idx })
+        e.idx = advanceIdx(e.idx, e.total)
+        e.weight--
+        remaining = true
+      }
+    }
+  }
+  return result
+}

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,0 +1,34 @@
+import { atomicWriteFile, readJsonWithRecovery } from './persistence'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+async function makeTempDir() {
+  return await fs.mkdtemp(path.join(tmpdir(), 'persist-'))
+}
+
+describe('atomicWriteFile', () => {
+  it('writes and renames without tmp residue', async () => {
+    const dir = await makeTempDir()
+    const file = path.join(dir, 'prefs.json')
+    await atomicWriteFile(file, '{"a":1}')
+    const data = await fs.readFile(file, 'utf8')
+    expect(JSON.parse(data)).toEqual({ a: 1 })
+    const files = await fs.readdir(dir)
+    expect(files).toEqual(['prefs.json'])
+  })
+})
+
+describe('readJsonWithRecovery', () => {
+  it('recovers from leftover tmp file', async () => {
+    const dir = await makeTempDir()
+    const file = path.join(dir, 'prefs.json')
+    const tmp = file + '.tmp'
+    await fs.writeFile(tmp, '{"b":2}')
+    const data = await readJsonWithRecovery<any>(file)
+    expect(data).toEqual({ b: 2 })
+    const files = await fs.readdir(dir)
+    expect(files).toEqual(['prefs.json'])
+  })
+})

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,0 +1,29 @@
+import { promises as fs } from 'fs'
+import { existsSync } from 'fs'
+
+/**
+ * Atomically write data to a file using a temporary .tmp file then rename.
+ */
+export async function atomicWriteFile(path: string, data: string | Buffer): Promise<void> {
+  const tmp = path + '.tmp'
+  const handle = await fs.open(tmp, 'w')
+  try {
+    await handle.writeFile(data)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  await fs.rename(tmp, path)
+}
+
+/**
+ * Read a JSON file, recovering from a leftover .tmp if present.
+ */
+export async function readJsonWithRecovery<T>(path: string): Promise<T> {
+  const tmp = path + '.tmp'
+  if (existsSync(tmp) && !existsSync(path)) {
+    await fs.rename(tmp, path)
+  }
+  const text = await fs.readFile(path, 'utf8')
+  return JSON.parse(text) as T
+}

--- a/src/saveManager.test.ts
+++ b/src/saveManager.test.ts
@@ -1,0 +1,124 @@
+import { SaveManager } from './saveManager'
+import { awardXpAndSave } from './awardXp'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { describe, it, expect, vi } from 'vitest'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+function sampleState() {
+  return {
+    mastery: { format: 'Mastery-v2', ass: {}, topics: {} },
+    attempts: { format: 'Attempts-v1', ass: {}, topics: {} },
+    xp: { format: 'XP-v1', log: [] },
+    prefs: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+  }
+}
+
+describe('SaveManager', () => {
+  it('loads and autosaves state', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.load()
+    await awardXpAndSave(manager, 5, 'test', new Date('2025-01-01T00:00:00Z'))
+
+    const files = (await fs.readdir(dir)).sort()
+    expect(files).toEqual(['attempt_window.json', 'mastery.json', 'prefs.json', 'xp.json'])
+    const xp = JSON.parse(await fs.readFile(path.join(dir, 'xp.json'), 'utf8'))
+    expect(xp.log.length).toBe(1)
+    expect(xp.log[0].delta).toBe(5)
+  })
+
+  it('migrates older prefs file', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    const oldPrefs = { format: 'Prefs-v0', xp_since_mixed_quiz: 0, last_as: null }
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(oldPrefs))
+
+    const manager = new SaveManager(dir)
+    const now = new Date('2025-01-01T00:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    await manager.load()
+    vi.useRealTimers()
+
+    expect(manager.prefs).toEqual({ format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' })
+    const backupDir = path.join(dir, 'backup_20250101')
+    const backups = await fs.readdir(backupDir)
+    expect(backups).toContain('prefs.json')
+  })
+
+  it('exports and imports progress', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.load()
+
+    const zipPath = path.join(dir, 'export.zip')
+    await manager.exportProgress(zipPath)
+
+    const dir2 = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const manager2 = new SaveManager(dir2)
+    await manager2.importProgress(zipPath)
+
+    for (const f of ['mastery.json', 'attempt_window.json', 'xp.json', 'prefs.json']) {
+      const a = await fs.readFile(path.join(dir, f), 'utf8')
+      const b = await fs.readFile(path.join(dir2, f), 'utf8')
+      expect(b).toBe(a)
+    }
+  })
+
+  it('rejects import when format newer', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(tmpdir(), 'bundle-'))
+    const files = sampleState()
+    await fs.writeFile(path.join(tmpDir, 'mastery.json'), JSON.stringify(files.mastery))
+    await fs.writeFile(path.join(tmpDir, 'attempt_window.json'), JSON.stringify(files.attempts))
+    await fs.writeFile(path.join(tmpDir, 'xp.json'), JSON.stringify(files.xp))
+    await fs.writeFile(path.join(tmpDir, 'prefs.json'), JSON.stringify({ format: 'Prefs-v99' }))
+    const zipPath = path.join(tmpDir, 'bundle.zip')
+    await execFileAsync('zip', ['-q', '-j', zipPath, 'mastery.json', 'attempt_window.json', 'xp.json', 'prefs.json'], { cwd: tmpDir })
+
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const manager = new SaveManager(dir)
+    await expect(manager.importProgress(zipPath)).rejects.toThrow()
+  })
+
+  it('resetProfile archives and seeds blanks', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.resetProfile()
+
+    const parent = path.dirname(dir)
+    const archives = await fs.readdir(path.join(parent, 'archive'))
+    expect(archives.length).toBeGreaterThanOrEqual(1)
+
+    const files = (await fs.readdir(dir)).sort()
+    expect(files).toEqual(['attempt_window.json', 'mastery.json', 'prefs.json', 'xp.json'])
+    const mastery = JSON.parse(await fs.readFile(path.join(dir, 'mastery.json'), 'utf8'))
+    expect(mastery.ass).toEqual({})
+  })
+})
+

--- a/src/saveManager.ts
+++ b/src/saveManager.ts
@@ -1,0 +1,157 @@
+import path from 'path'
+import { promises as fs } from 'fs'
+import { atomicWriteFile } from './persistence'
+import { loadWithMigrations } from './migrations'
+import { Prefs, XpLog } from './awardXp'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { tmpdir } from 'os'
+
+export interface MasteryFile {
+  format: string
+  ass: Record<string, unknown>
+  topics: Record<string, any>
+}
+
+export interface AttemptsFile {
+  format: string
+  ass: Record<string, unknown>
+  topics: Record<string, unknown>
+}
+
+export interface SaveState {
+  mastery: MasteryFile
+  attempts: AttemptsFile
+  xp: XpLog
+  prefs: Prefs
+}
+
+export interface SaveManagerOptions {
+  toast?: (msg: string) => void
+  initialDelayMs?: number
+  maxDelayMs?: number
+}
+
+export class SaveManager implements SaveState {
+  mastery!: MasteryFile
+  attempts!: AttemptsFile
+  xp!: XpLog
+  prefs!: Prefs
+
+  private consecutiveFails = 0
+  private options: SaveManagerOptions
+
+  constructor(public dir: string, options: SaveManagerOptions = {}) {
+    this.options = options
+  }
+
+  private seedBlank() {
+    this.mastery = { format: 'Mastery-v2', ass: {}, topics: {} }
+    this.attempts = { format: 'Attempts-v1', ass: {}, topics: {} }
+    this.xp = { format: 'XP-v1', log: [] }
+    this.prefs = {
+      format: 'Prefs-v2',
+      profile: path.basename(this.dir),
+      xp_since_mixed_quiz: 0,
+      last_as: null,
+      ui_theme: 'default'
+    }
+  }
+
+  private static execFile = promisify(execFile)
+
+  private static versionGt(a: string, b: string): boolean {
+    const get = (v: string) => {
+      const m = v.match(/v(\d+)/)
+      return m ? parseInt(m[1]) : 0
+    }
+    return get(a) > get(b)
+  }
+
+  async load() {
+    this.mastery = await loadWithMigrations<MasteryFile>(path.join(this.dir, 'mastery.json'), 'Mastery-v2')
+    this.attempts = await loadWithMigrations<AttemptsFile>(path.join(this.dir, 'attempt_window.json'), 'Attempts-v1')
+    this.xp = await loadWithMigrations<XpLog>(path.join(this.dir, 'xp.json'), 'XP-v1')
+    this.prefs = await loadWithMigrations<Prefs>(path.join(this.dir, 'prefs.json'), 'Prefs-v2')
+  }
+
+  private async writeAll() {
+    await fs.mkdir(this.dir, { recursive: true })
+    await Promise.all([
+      atomicWriteFile(path.join(this.dir, 'mastery.json'), JSON.stringify(this.mastery, null, 2)),
+      atomicWriteFile(path.join(this.dir, 'attempt_window.json'), JSON.stringify(this.attempts, null, 2)),
+      atomicWriteFile(path.join(this.dir, 'xp.json'), JSON.stringify(this.xp, null, 2)),
+      atomicWriteFile(path.join(this.dir, 'prefs.json'), JSON.stringify(this.prefs, null, 2)),
+    ])
+  }
+
+  async autosave() {
+    let delay = this.options.initialDelayMs ?? 100
+    const maxDelay = this.options.maxDelayMs ?? 32000
+    while (true) {
+      try {
+        await this.writeAll()
+        this.consecutiveFails = 0
+        return
+      } catch (err) {
+        this.consecutiveFails++
+        if (this.consecutiveFails >= 3 && this.options.toast) {
+          this.options.toast('Autosave failed')
+        }
+        await new Promise((res) => setTimeout(res, delay))
+        delay = Math.min(delay * 2, maxDelay)
+      }
+    }
+  }
+
+  async exportProgress(outFile: string) {
+    await SaveManager.execFile('zip', [
+      '-q',
+      '-j',
+      outFile,
+      'mastery.json',
+      'attempt_window.json',
+      'xp.json',
+      'prefs.json',
+    ], { cwd: this.dir })
+  }
+
+  async importProgress(zipFile: string) {
+    const tmp = await fs.mkdtemp(path.join(tmpdir(), 'import-'))
+    await SaveManager.execFile('unzip', ['-qq', zipFile, '-d', tmp])
+
+    const files = {
+      mastery: 'Mastery-v2',
+      attempt_window: 'Attempts-v1',
+      xp: 'XP-v1',
+      prefs: 'Prefs-v2',
+    }
+
+    for (const [name, fmt] of Object.entries(files)) {
+      const p = path.join(tmp, `${name}.json`)
+      const data = JSON.parse(await fs.readFile(p, 'utf8'))
+      if (SaveManager.versionGt(data.format, fmt)) {
+        throw new Error('Unsupported format')
+      }
+    }
+
+    await fs.mkdir(this.dir, { recursive: true })
+    for (const name of Object.keys(files)) {
+      await fs.copyFile(path.join(tmp, `${name}.json`), path.join(this.dir, `${name}.json`))
+    }
+  }
+
+  async resetProfile() {
+    const ts = new Date().toISOString().replace(/[-:]/g, '').slice(0, 15)
+    const archiveRoot = path.join(path.dirname(this.dir), 'archive')
+    await fs.mkdir(archiveRoot, { recursive: true })
+    const dest = path.join(archiveRoot, ts)
+    if (await fs.stat(this.dir).catch(() => false)) {
+      await fs.rename(this.dir, dest)
+    }
+    await fs.mkdir(this.dir, { recursive: true })
+    this.seedBlank()
+    await this.writeAll()
+  }
+}
+

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { generateCandidates, DistMatrix, SkillMeta } from './scheduler'
+import { MasteryEntry } from './updateMastery'
+import { Prefs, XpLog } from './awardXp'
+
+function entry(status: 'unseen' | 'in_progress' | 'mastered', due: string): MasteryEntry {
+  return { status, s: 0, d: 0, r: 0, l: 0, next_due: due, next_q_index: 0 }
+}
+
+const skills: Record<string, SkillMeta> = {
+  A: { id: "A", topic: "T0", prereqs: ["P"] },
+  P: { id: 'P', topic: 'T0' }
+}
+
+const dist: DistMatrix = { P: { A: 2 } }
+
+const xp: XpLog = { format: 'XP-v1', log: [{ id: 1, ts: '2025-01-10T00:00:00Z', delta: 10, source: 'P_q1' }] }
+
+const prefs: Prefs = { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: 'P', ui_theme: 'default' }
+
+const now = new Date('2025-01-10T00:05:00Z')
+
+describe('generateCandidates', () => {
+  it('prioritizes overdue review with bonuses', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('in_progress', '2025-01-07T00:00:00Z'),
+      P: entry('in_progress', '2025-01-08T00:00:00Z')
+    }
+    const cand = generateCandidates(skills, mastery, { ...prefs, last_as: "P" }, { format: "XP-v1", log: [{ id: 1, ts: "2025-01-09T23:40:00Z", delta: 10, source: "P_q1" }] }, dist, now)
+    expect(cand[0]).toEqual({ id: 'A', kind: 'review', priority: 5 + 3 + 3 + 2 })
+  })
+
+  it('includes new skills when prereqs mastered', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('unseen', '2025-01-15T00:00:00Z'),
+      P: entry('mastered', '2025-01-01T00:00:00Z')
+    }
+    const cand = generateCandidates(skills, mastery, { ...prefs, last_as: null }, xp, dist, now)
+    expect(cand.some(c => c.id === "A" && c.kind === "new_as")).toBe(true)
+  })
+
+  it('omits candidate when non-interference gap not elapsed', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      P: entry('in_progress', '2025-01-08T00:00:00Z'),
+      A: entry('in_progress', '2025-01-07T00:00:00Z')
+    }
+    const recentXp: XpLog = { format: 'XP-v1', log: [{ id: 1, ts: '2025-01-10T00:04:00Z', delta: 10, source: 'P_q1' }] }
+    const cand = generateCandidates(skills, mastery, { ...prefs, last_as: 'P' }, recentXp, dist, now)
+    expect(cand.length).toBe(0)
+  })
+
+  it('adds mixed quiz when xp threshold met', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: entry('unseen', '2025-01-15T00:00:00Z'),
+      P: entry('mastered', '2025-01-01T00:00:00Z')
+    }
+    const cand = generateCandidates(skills, mastery, { ...prefs, xp_since_mixed_quiz: 200 }, xp, dist, now)
+    const mq = cand.find(c => c.kind === 'mixed_quiz')
+    expect(mq).toBeDefined()
+  })
+})

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,102 @@
+import { prerequisitesMastered } from './unlock'
+import { Prefs, XpLog } from './awardXp'
+import { MasteryEntry } from './updateMastery'
+
+export interface SkillMeta {
+  id: string
+  topic: string
+  prereqs?: string[]
+}
+
+export interface DistMatrix {
+  [src: string]: Record<string, number>
+}
+
+export interface Candidate {
+  id: string
+  kind: 'review' | 'new_as' | 'mixed_quiz'
+  priority: number
+}
+
+const REVIEW_GAP_MIN_M = 10
+const MIXED_QUIZ_TRIGGER_XP = 150
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((a.getTime() - b.getTime()) / 86400_000)
+}
+
+function distanceBonus(last: string | null, target: string, dist: DistMatrix): number {
+  if (!last) return 5
+  const d = dist[last]?.[target]
+  if (d === undefined) return 5
+  return Math.min(5, d)
+}
+
+function lastAttemptTime(asId: string, xp: XpLog): Date | undefined {
+  for (let i = xp.log.length - 1; i >= 0; i--) {
+    const entry = xp.log[i]
+    if (entry.source.startsWith(asId)) {
+      return new Date(entry.ts)
+    }
+  }
+}
+
+function shouldRejectForGap(
+  skills: Record<string, SkillMeta>,
+  candidate: SkillMeta,
+  prefs: Prefs,
+  xp: XpLog,
+  now: Date,
+): boolean {
+  const lastId = prefs.last_as
+  if (!lastId) return false
+  const lastSkill = skills[lastId]
+  if (!lastSkill) return false
+  if (lastSkill.topic !== candidate.topic) return false
+  const lastTime = lastAttemptTime(lastId, xp)
+  if (!lastTime) return false
+  return (now.getTime() - lastTime.getTime()) / 60000 < REVIEW_GAP_MIN_M
+}
+
+export function generateCandidates(
+  skills: Record<string, SkillMeta>,
+  mastery: Record<string, MasteryEntry>,
+  prefs: Prefs,
+  xp: XpLog,
+  dist: DistMatrix,
+  now: Date = new Date(),
+): Candidate[] {
+  const list: Candidate[] = []
+  for (const skill of Object.values(skills)) {
+    const m = mastery[skill.id]
+    if (!m) continue
+    if (shouldRejectForGap(skills, skill, prefs, xp, now)) continue
+
+    const due = new Date(m.next_due)
+    const overdueDays = daysBetween(now, due)
+    if (m.status !== 'unseen' && overdueDays >= 0) {
+      const overdueBonus = Math.min(Math.max(overdueDays, 0), 5)
+      const overduePrereqs = skill.prereqs?.filter(p => {
+        const pm = mastery[p]
+        return pm && pm.status !== 'unseen' && new Date(pm.next_due) <= now
+      }).length ?? 0
+      const priority =
+        5 +
+        overdueBonus +
+        3 * overduePrereqs +
+        distanceBonus(prefs.last_as, skill.id, dist)
+      list.push({ id: skill.id, kind: 'review', priority })
+    } else if (m.status === 'unseen' && prerequisitesMastered(skill, mastery)) {
+      const priority =
+        3 +
+        0 +
+        0 +
+        distanceBonus(prefs.last_as, skill.id, dist)
+      list.push({ id: skill.id, kind: 'new_as', priority })
+    }
+  }
+  if (prefs.xp_since_mixed_quiz >= MIXED_QUIZ_TRIGGER_XP) {
+    list.push({ id: 'mixed_quiz', kind: 'mixed_quiz', priority: 2 })
+  }
+  return list.sort((a, b) => b.priority - a.priority)
+}

--- a/src/schemaValidation.test.ts
+++ b/src/schemaValidation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { readFile } from 'fs/promises'
+import path from 'path'
+import Ajv from 'ajv'
+import { load as loadYaml } from 'js-yaml'
+
+const ajv = new Ajv()
+
+async function loadJson(file: string) {
+  const txt = await readFile(file, 'utf8')
+  return JSON.parse(txt)
+}
+
+async function validate(schemaFile: string, dataFile: string, isYaml = false) {
+  const schema = await loadJson(schemaFile)
+  const validateFn = ajv.compile(schema)
+  const dataTxt = await readFile(dataFile, 'utf8')
+  const data = isYaml ? loadYaml(dataTxt) : JSON.parse(dataTxt)
+  const valid = validateFn(data)
+  if (!valid) console.error(validateFn.errors)
+  expect(valid).toBe(true)
+}
+
+describe('sample data matches JSON schemas', () => {
+  const root = process.cwd()
+  it('validates courses.json', async () => {
+    await validate(path.join(root, 'schema/courses-v1.json'), path.join(root, 'courses.json'))
+  })
+  it('validates catalog', async () => {
+    await validate(path.join(root, 'schema/catalog-v1.json'), path.join(root, 'course/ea/catalog.json'))
+  })
+  it('validates topics', async () => {
+    const schema = path.join(root, 'schema/topic-v1.json')
+    for (const f of ['T001.json','T002.json']) {
+      await validate(schema, path.join(root, 'course/ea/topics', f))
+    }
+  })
+  it('validates skills', async () => {
+    const schema = path.join(root, 'schema/skill-v1.json')
+    for (const num of ['001','003','004','013']) {
+      const f = `A${'S'}${num}.json`
+      await validate(schema, path.join(root, 'course/ea/skills', f))
+    }
+  })
+  it('validates question YAML', async () => {
+    const schema = path.join(root, 'schema/asq-v1.json')
+    for (const num of ['001','003','004','013']) {
+      const f = `A${'S'}${num}.yaml`
+      await validate(schema, path.join(root, 'course/ea/as_questions', f), true)
+    }
+  })
+  it('validates save files', async () => {
+    await validate(path.join(root, 'schema/mastery-v2.json'), path.join(root, 'save/mastery.json'))
+    await validate(path.join(root, 'schema/attempts-v1.json'), path.join(root, 'save/attempt_window.json'))
+    await validate(path.join(root, 'schema/xp-v1.json'), path.join(root, 'save/xp.json'))
+    await validate(path.join(root, 'schema/prefs-v2.json'), path.join(root, 'save/prefs.json'))
+  })
+})

--- a/src/unlock.test.ts
+++ b/src/unlock.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { prerequisitesMastered, SkillData, MasteryEntry } from './unlock'
+
+describe('prerequisitesMastered', () => {
+  const mastery: Record<string, MasteryEntry> = {
+    s1: { status: 'mastered' },
+    s2: { status: 'mastered' },
+    s3: { status: 'in_progress' },
+  }
+
+  it('returns true when no prereqs', () => {
+    const skill: SkillData = { id: 'A', name: 'A' }
+    expect(prerequisitesMastered(skill, mastery)).toBe(true)
+  })
+
+  it('returns true when all prereqs mastered', () => {
+    const skill: SkillData = { id: 'B', name: 'B', prereqs: ['s1', 's2'] }
+    expect(prerequisitesMastered(skill, mastery)).toBe(true)
+  })
+
+  it('returns false when any prereq not mastered', () => {
+    const skill: SkillData = { id: 'C', name: 'C', prereqs: ['s1', 's3'] }
+    expect(prerequisitesMastered(skill, mastery)).toBe(false)
+  })
+
+  it('returns false when mastery entry missing', () => {
+    const skill: SkillData = { id: 'D', name: 'D', prereqs: ['s1', 's4'] }
+    expect(prerequisitesMastered(skill, mastery)).toBe(false)
+  })
+})

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -1,0 +1,22 @@
+export interface SkillData {
+  id: string
+  name: string
+  prereqs?: string[]
+  weights?: Record<string, number>
+}
+
+export interface MasteryEntry {
+  status: 'unseen' | 'in_progress' | 'mastered'
+  // other fields ignored
+}
+
+/**
+ * Return true if all prerequisites for this skill are mastered.
+ */
+export function prerequisitesMastered(
+  skill: SkillData,
+  mastery: Record<string, MasteryEntry | undefined>
+): boolean {
+  if (!skill.prereqs || skill.prereqs.length === 0) return true
+  return skill.prereqs.every((id) => mastery[id]?.status === 'mastered')
+}

--- a/src/updateMastery.test.ts
+++ b/src/updateMastery.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { updateMastery, MasteryEntry, SkillMeta } from './updateMastery'
+import * as fsrsMod from './fsrs'
+
+function makeEntry(): MasteryEntry {
+  return {
+    status: 'unseen',
+    s: 0,
+    d: 0,
+    r: 0,
+    l: 0,
+    next_due: '2025-01-01T00:00:00.000Z',
+    next_q_index: 0
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('updateMastery', () => {
+  it('updates main skill and increments question index', () => {
+    const mastery: Record<string, MasteryEntry> = { A: makeEntry() }
+    const skill: SkillMeta = { id: 'A', name: 'A' }
+
+    vi.spyOn(fsrsMod, 'nextReview').mockReturnValue({
+      stability: 0.5,
+      difficulty: 0.4,
+      reps: 1,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 1
+    } as any)
+
+    updateMastery(mastery, skill, 5, 5, new Date('2025-01-01T00:00:00Z'))
+
+    expect(mastery.A.s).toBe(0.5)
+    expect(mastery.A.next_q_index).toBe(1)
+    expect(mastery.A.next_due).toBe('2025-01-02T00:00:00.000Z')
+  })
+
+  it('applies implicit credit to prerequisites when grade>=4', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: makeEntry(),
+      P: makeEntry()
+    }
+    const skill: SkillMeta = { id: 'A', name: 'A', prereqs: ['P'], weights: { P: 0.5 } }
+
+    const mainNext = {
+      stability: 0.5,
+      difficulty: 0.4,
+      reps: 1,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 1
+    }
+    const prereqNext = {
+      stability: 0.9,
+      difficulty: 0.8,
+      reps: 2,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 4
+    }
+    const spy = vi.spyOn(fsrsMod, 'nextReview')
+    spy.mockReturnValueOnce(mainNext as any).mockReturnValueOnce(prereqNext as any)
+
+    updateMastery(mastery, skill, 5, 5, new Date('2025-01-01T00:00:00Z'))
+
+    // main updated
+    expect(mastery.A.s).toBe(0.5)
+    // prereq interval damped: 0.3 * 0.5 * 4 = 0.6 -> round ->1
+    expect(mastery.P.next_due).toBe('2025-01-02T00:00:00.000Z')
+    expect(mastery.P.s).toBe(0.9)
+  })
+
+  it('skips implicit credit when grade<4', () => {
+    const mastery: Record<string, MasteryEntry> = {
+      A: makeEntry(),
+      P: makeEntry()
+    }
+    const skill: SkillMeta = { id: 'A', name: 'A', prereqs: ['P'] }
+
+    vi.spyOn(fsrsMod, 'nextReview').mockReturnValue({
+      stability: 0.5,
+      difficulty: 0.4,
+      reps: 1,
+      lapses: 0,
+      due: new Date('2025-01-02T00:00:00Z'),
+      scheduled_days: 2
+    } as any)
+
+    updateMastery(mastery, skill, 3, 5, new Date('2025-01-01T00:00:00Z'))
+
+    expect(mastery.P.next_due).toBe('2025-01-01T00:00:00.000Z')
+  })
+})

--- a/src/updateMastery.ts
+++ b/src/updateMastery.ts
@@ -1,0 +1,88 @@
+export interface MasteryEntry {
+  status: 'unseen' | 'in_progress' | 'mastered'
+  s: number
+  d: number
+  r: number
+  l: number
+  next_due: string
+  next_q_index: number
+}
+
+export interface SkillMeta {
+  id: string
+  name: string
+  prereqs?: string[]
+  weights?: Record<string, number>
+}
+
+import { nextReview } from './fsrs'
+import { advanceIdx } from './advanceIdx'
+
+const ALPHA_IMPLICIT = 0.3
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 86400_000)
+}
+
+function toCard(entry: MasteryEntry) {
+  return {
+    due: new Date(entry.next_due),
+    stability: entry.s,
+    difficulty: entry.d,
+    reps: entry.r,
+    lapses: entry.l,
+    elapsed_days: 0,
+    scheduled_days: 0,
+    learning_steps: 0,
+    state: 0
+  }
+}
+
+/**
+ * Update mastery state for an answered skill and apply implicit
+ * prerequisite credit when grade \u2265 4.
+ * Mutates the mastery record in place.
+ */
+export function updateMastery(
+  mastery: Record<string, MasteryEntry>,
+  skill: SkillMeta,
+  grade: number,
+  totalQuestions: number,
+  now: Date = new Date()
+): void {
+  const entry = mastery[skill.id]
+  if (!entry) return
+
+  const card = toCard(entry)
+  const next = nextReview(card, grade)
+
+  mastery[skill.id] = {
+    status: 'in_progress',
+    s: next.stability,
+    d: next.difficulty,
+    r: next.reps,
+    l: next.lapses,
+    next_due: next.due.toISOString(),
+    next_q_index: advanceIdx(entry.next_q_index, totalQuestions)
+  }
+
+  if (grade >= 4 && skill.prereqs) {
+    for (const p of skill.prereqs) {
+      const m = mastery[p]
+      if (!m) continue
+      const weight = skill.weights?.[p] ?? 1
+      const pNext = nextReview(toCard(m), 4)
+      const interval = pNext.scheduled_days
+      const damp = Math.max(1, Math.round(ALPHA_IMPLICIT * weight * interval))
+      mastery[p] = {
+        status: m.status,
+        s: pNext.stability,
+        d: pNext.difficulty,
+        r: pNext.reps,
+        l: pNext.lapses,
+        next_due: addDays(now, damp).toISOString(),
+        next_q_index: m.next_q_index
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `loadMarkdown` and `loadYaml` helper functions that return a placeholder when a file can't be loaded
- test loader behaviour for successful fetches, failures and network errors
- remove completed TODO item about missing Markdown/YAML handling

## Testing
- `npm test`