### PR TITLE
Implement progress export/import and reset features

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,4 +30,3 @@ file before committing.
 # Additional tasks identified during comparison with docs/design_doc.md
 - [ ] Support hot-reloading of JSON edits without restarting the app.
 - [ ] Implement cross-course remediation scheduling when prerequisites from other courses are overdue.
-- [ ] Cap in-memory distance matrix to 1000x1000 entries and compute others on demand.

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ file before committing.
 - [ ] Ensure `npm test` runs all tests and `npm run dev` starts without console errors.
 
 ## Packaging & Misc
-- [ ] Implement export/import of progress and course reset features.
+
 # Additional tasks identified during comparison with docs/design_doc.md
 - [ ] Support hot-reloading of JSON edits without restarting the app.
 - [ ] Implement cross-course remediation scheduling when prerequisites from other courses are overdue.

--- a/src/distanceMatrix.test.ts
+++ b/src/distanceMatrix.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { DistanceMatrix, Adjacency } from './distanceMatrix'
+
+const graph: Adjacency = {
+  A: ['B', 'D'],
+  B: ['A', 'C'],
+  C: ['B'],
+  D: ['A']
+}
+
+describe('DistanceMatrix', () => {
+  it('computes bfs distance and caches within limit', () => {
+    const dm = new DistanceMatrix(graph, 3)
+    expect(dm.getDistance('A', 'C')).toBe(2)
+    expect(dm.matrix['A']['C']).toBe(2)
+    expect(Object.keys(dm.matrix).length).toBeLessThanOrEqual(3)
+  })
+
+  it('does not cache when limit exceeded', () => {
+    const dm = new DistanceMatrix(graph, 2)
+    dm.getDistance('A', 'B')
+    dm.getDistance('A', 'C')
+    expect(dm.matrix['A']['B']).toBe(1)
+    expect(dm.matrix['A']['C']).toBeUndefined()
+  })
+
+  it('returns undefined when nodes disconnected', () => {
+    const dm = new DistanceMatrix(graph, 3)
+    expect(dm.getDistance('A', 'Z')).toBeUndefined()
+  })
+})

--- a/src/distanceMatrix.ts
+++ b/src/distanceMatrix.ts
@@ -1,0 +1,52 @@
+export interface Adjacency {
+  [node: string]: string[]
+}
+
+export interface DistMatrix {
+  [src: string]: Record<string, number>
+}
+
+export class DistanceMatrix {
+  matrix: DistMatrix = {}
+  private nodes = new Set<string>()
+
+  constructor(private graph: Adjacency, private limit = 1000) {}
+
+  private store(a: string, b: string, d: number) {
+    if (!this.matrix[a]) this.matrix[a] = {}
+    if (!this.matrix[b]) this.matrix[b] = {}
+    this.matrix[a][b] = d
+    this.matrix[b][a] = d
+    this.nodes.add(a)
+    this.nodes.add(b)
+  }
+
+  private bfs(a: string, b: string): number | undefined {
+    if (a === b) return 0
+    const visited = new Set<string>([a])
+    const queue: Array<{ n: string; d: number }> = [{ n: a, d: 0 }]
+    while (queue.length) {
+      const { n, d } = queue.shift()!
+      for (const nbr of this.graph[n] || []) {
+        if (nbr === b) return d + 1
+        if (!visited.has(nbr)) {
+          visited.add(nbr)
+          queue.push({ n: nbr, d: d + 1 })
+        }
+      }
+    }
+    return undefined
+  }
+
+  getDistance(a: string, b: string): number | undefined {
+    const cached = this.matrix[a]?.[b]
+    if (cached !== undefined) return cached
+    const dist = this.bfs(a, b)
+    if (dist === undefined) return undefined
+    const newNodes = [a, b].filter((n) => !this.nodes.has(n))
+    if (this.nodes.size + newNodes.length <= this.limit) {
+      this.store(a, b, dist)
+    }
+    return dist
+  }
+}

--- a/src/saveManager.test.ts
+++ b/src/saveManager.test.ts
@@ -4,6 +4,10 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { tmpdir } from 'os'
 import { describe, it, expect, vi } from 'vitest'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
 
 function sampleState() {
   return {
@@ -54,6 +58,67 @@ describe('SaveManager', () => {
     const backupDir = path.join(dir, 'backup_20250101')
     const backups = await fs.readdir(backupDir)
     expect(backups).toContain('prefs.json')
+  })
+
+  it('exports and imports progress', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.load()
+
+    const zipPath = path.join(dir, 'export.zip')
+    await manager.exportProgress(zipPath)
+
+    const dir2 = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const manager2 = new SaveManager(dir2)
+    await manager2.importProgress(zipPath)
+
+    for (const f of ['mastery.json', 'attempt_window.json', 'xp.json', 'prefs.json']) {
+      const a = await fs.readFile(path.join(dir, f), 'utf8')
+      const b = await fs.readFile(path.join(dir2, f), 'utf8')
+      expect(b).toBe(a)
+    }
+  })
+
+  it('rejects import when format newer', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(tmpdir(), 'bundle-'))
+    const files = sampleState()
+    await fs.writeFile(path.join(tmpDir, 'mastery.json'), JSON.stringify(files.mastery))
+    await fs.writeFile(path.join(tmpDir, 'attempt_window.json'), JSON.stringify(files.attempts))
+    await fs.writeFile(path.join(tmpDir, 'xp.json'), JSON.stringify(files.xp))
+    await fs.writeFile(path.join(tmpDir, 'prefs.json'), JSON.stringify({ format: 'Prefs-v99' }))
+    const zipPath = path.join(tmpDir, 'bundle.zip')
+    await execFileAsync('zip', ['-q', '-j', zipPath, 'mastery.json', 'attempt_window.json', 'xp.json', 'prefs.json'], { cwd: tmpDir })
+
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const manager = new SaveManager(dir)
+    await expect(manager.importProgress(zipPath)).rejects.toThrow()
+  })
+
+  it('resetProfile archives and seeds blanks', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'save-'))
+    const state = sampleState()
+    await fs.writeFile(path.join(dir, 'mastery.json'), JSON.stringify(state.mastery))
+    await fs.writeFile(path.join(dir, 'attempt_window.json'), JSON.stringify(state.attempts))
+    await fs.writeFile(path.join(dir, 'xp.json'), JSON.stringify(state.xp))
+    await fs.writeFile(path.join(dir, 'prefs.json'), JSON.stringify(state.prefs))
+
+    const manager = new SaveManager(dir)
+    await manager.resetProfile()
+
+    const parent = path.dirname(dir)
+    const archives = await fs.readdir(path.join(parent, 'archive'))
+    expect(archives.length).toBeGreaterThanOrEqual(1)
+
+    const files = (await fs.readdir(dir)).sort()
+    expect(files).toEqual(['attempt_window.json', 'mastery.json', 'prefs.json', 'xp.json'])
+    const mastery = JSON.parse(await fs.readFile(path.join(dir, 'mastery.json'), 'utf8'))
+    expect(mastery.ass).toEqual({})
   })
 })
 

--- a/src/saveManager.ts
+++ b/src/saveManager.ts
@@ -3,6 +3,9 @@ import { promises as fs } from 'fs'
 import { atomicWriteFile } from './persistence'
 import { loadWithMigrations } from './migrations'
 import { Prefs, XpLog } from './awardXp'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { tmpdir } from 'os'
 
 export interface MasteryFile {
   format: string
@@ -42,6 +45,29 @@ export class SaveManager implements SaveState {
     this.options = options
   }
 
+  private seedBlank() {
+    this.mastery = { format: 'Mastery-v2', ass: {}, topics: {} }
+    this.attempts = { format: 'Attempts-v1', ass: {}, topics: {} }
+    this.xp = { format: 'XP-v1', log: [] }
+    this.prefs = {
+      format: 'Prefs-v2',
+      profile: path.basename(this.dir),
+      xp_since_mixed_quiz: 0,
+      last_as: null,
+      ui_theme: 'default'
+    }
+  }
+
+  private static execFile = promisify(execFile)
+
+  private static versionGt(a: string, b: string): boolean {
+    const get = (v: string) => {
+      const m = v.match(/v(\d+)/)
+      return m ? parseInt(m[1]) : 0
+    }
+    return get(a) > get(b)
+  }
+
   async load() {
     this.mastery = await loadWithMigrations<MasteryFile>(path.join(this.dir, 'mastery.json'), 'Mastery-v2')
     this.attempts = await loadWithMigrations<AttemptsFile>(path.join(this.dir, 'attempt_window.json'), 'Attempts-v1')
@@ -76,6 +102,56 @@ export class SaveManager implements SaveState {
         delay = Math.min(delay * 2, maxDelay)
       }
     }
+  }
+
+  async exportProgress(outFile: string) {
+    await SaveManager.execFile('zip', [
+      '-q',
+      '-j',
+      outFile,
+      'mastery.json',
+      'attempt_window.json',
+      'xp.json',
+      'prefs.json',
+    ], { cwd: this.dir })
+  }
+
+  async importProgress(zipFile: string) {
+    const tmp = await fs.mkdtemp(path.join(tmpdir(), 'import-'))
+    await SaveManager.execFile('unzip', ['-qq', zipFile, '-d', tmp])
+
+    const files = {
+      mastery: 'Mastery-v2',
+      attempt_window: 'Attempts-v1',
+      xp: 'XP-v1',
+      prefs: 'Prefs-v2',
+    }
+
+    for (const [name, fmt] of Object.entries(files)) {
+      const p = path.join(tmp, `${name}.json`)
+      const data = JSON.parse(await fs.readFile(p, 'utf8'))
+      if (SaveManager.versionGt(data.format, fmt)) {
+        throw new Error('Unsupported format')
+      }
+    }
+
+    await fs.mkdir(this.dir, { recursive: true })
+    for (const name of Object.keys(files)) {
+      await fs.copyFile(path.join(tmp, `${name}.json`), path.join(this.dir, `${name}.json`))
+    }
+  }
+
+  async resetProfile() {
+    const ts = new Date().toISOString().replace(/[-:]/g, '').slice(0, 15)
+    const archiveRoot = path.join(path.dirname(this.dir), 'archive')
+    await fs.mkdir(archiveRoot, { recursive: true })
+    const dest = path.join(archiveRoot, ts)
+    if (await fs.stat(this.dir).catch(() => false)) {
+      await fs.rename(this.dir, dest)
+    }
+    await fs.mkdir(this.dir, { recursive: true })
+    this.seedBlank()
+    await this.writeAll()
   }
 }
 


### PR DESCRIPTION
## Summary
- add progress export/import and profile reset logic to SaveManager
- test exporting/importing progress data and resetting
- remove completed TODO item

## Testing
- `npm test`
- `npm run dev`