### PR TITLE
Add course registry loader

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ This list should be kept up to date.  When a task is finished, remove it from th
 file before committing.
 
 ## Core Data & Storage
-- Implement filesystem layout (`courses.json`, `course/<id>/`, `save/`, `.cache/`, etc.).
+
 
 ## Course Content
 

--- a/src/courseRegistry.test.ts
+++ b/src/courseRegistry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { loadCourseRegistry, loadCatalog } from './courseRegistry'
+
+const root = process.cwd()
+
+describe('loadCourseRegistry', () => {
+  it('loads sample registry', async () => {
+    const file = path.join(root, 'courses.json')
+    const courses = await loadCourseRegistry(file)
+    expect(courses.length).toBeGreaterThan(0)
+    expect(courses[0].id).toBe('EA')
+  })
+
+  it('throws on invalid registry', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'cr-'))
+    const file = path.join(dir, 'courses.json')
+    await fs.writeFile(file, JSON.stringify({ format: 'Courses-v1' }))
+    await expect(loadCourseRegistry(file)).rejects.toThrow()
+  })
+})
+
+describe('loadCatalog', () => {
+  it('loads sample catalog', async () => {
+    const file = path.join(root, 'course/ea/catalog.json')
+    const cat = await loadCatalog(file)
+    expect(cat.course_id).toBe('EA')
+    expect(cat.entry_topics.length).toBeGreaterThan(0)
+  })
+
+  it('throws on invalid catalog', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'cat-'))
+    const file = path.join(dir, 'catalog.json')
+    await fs.writeFile(file, JSON.stringify({ format: 'Catalog-v0' }))
+    await expect(loadCatalog(file)).rejects.toThrow()
+  })
+})

--- a/src/courseRegistry.ts
+++ b/src/courseRegistry.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export interface CourseEntry {
+  id: string
+  name: string
+  path: string
+}
+
+export interface CourseRegistry {
+  format: string
+  courses: CourseEntry[]
+}
+
+/**
+ * Load the global course registry from a JSON file.
+ */
+export async function loadCourseRegistry(file: string): Promise<CourseEntry[]> {
+  const text = await fs.readFile(file, 'utf8')
+  const data = JSON.parse(text) as CourseRegistry
+  if (data.format !== 'Courses-v1' || !Array.isArray(data.courses)) {
+    throw new Error('Invalid course registry')
+  }
+  return data.courses.map(c => ({ ...c, path: path.normalize(c.path) }))
+}
+
+export interface Catalog {
+  format: string
+  course_id: string
+  entry_topics: string[]
+  description: string
+}
+
+/**
+ * Load a course catalog file.
+ */
+export async function loadCatalog(file: string): Promise<Catalog> {
+  const text = await fs.readFile(file, 'utf8')
+  const data = JSON.parse(text) as Catalog
+  if (data.format !== 'Catalog-v1') {
+    throw new Error('Invalid catalog')
+  }
+  return data
+}


### PR DESCRIPTION
## Summary
- implement loader for `courses.json` and course catalogs
- test course registry and catalog loading
- remove completed TODO item

## Testing
- `npm test`