### PR TITLE
Integrate Redux store and SaveManager

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,34 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App.tsx';
-import { I18nProvider } from './i18n.tsx';
-import { ThemeProvider } from './theme.tsx';
-import 'mathjax/es5/tex-mml-chtml.js';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Provider } from 'react-redux'
+import { promises as fs } from 'fs'
+import path from 'path'
+import './index.css'
+import App from './App.tsx'
+import { I18nProvider } from './i18n.tsx'
+import { ThemeProvider } from './theme.tsx'
+import 'mathjax/es5/tex-mml-chtml.js'
+import { SaveManager } from './saveManager'
+import { createAppStore } from './store'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <I18nProvider>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </I18nProvider>
-  </StrictMode>,
-);
+async function start() {
+  const prefsRaw = await fs.readFile(path.join('save', 'prefs.json'), 'utf8')
+  const prefs = JSON.parse(prefsRaw) as { profile: string }
+  const manager = new SaveManager(prefs.profile)
+  await manager.load()
+  const store = createAppStore(manager)
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
+    </StrictMode>,
+  )
+}
+
+start()

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,93 @@
+import { configureStore, createSlice, PayloadAction, ThunkAction, AnyAction } from '@reduxjs/toolkit';
+import { SaveManager, MasteryFile, AttemptsFile } from './saveManager';
+import { XpLog, Prefs, awardXp } from './awardXp';
+import { updateMastery as updateMasteryFn, SkillMeta } from './updateMastery';
+
+export interface RootState {
+  mastery: MasteryFile;
+  attempts: AttemptsFile;
+  xp: XpLog;
+  prefs: Prefs;
+}
+
+const masterySlice = createSlice({
+  name: 'mastery',
+  initialState: { format: 'Mastery-v2', ass: {}, topics: {} } as MasteryFile,
+  reducers: {
+    setMastery: (_state, action: PayloadAction<MasteryFile>) => action.payload,
+  },
+});
+
+const attemptsSlice = createSlice({
+  name: 'attempts',
+  initialState: { format: 'Attempts-v1', ass: {}, topics: {} } as AttemptsFile,
+  reducers: {
+    setAttempts: (_state, action: PayloadAction<AttemptsFile>) => action.payload,
+  },
+});
+
+const xpSlice = createSlice({
+  name: 'xp',
+  initialState: { format: 'XP-v1', log: [] } as XpLog,
+  reducers: {
+    setXp: (_state, action: PayloadAction<XpLog>) => action.payload,
+  },
+});
+
+const prefsSlice = createSlice({
+  name: 'prefs',
+  initialState: { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' } as Prefs,
+  reducers: {
+    setPrefs: (_state, action: PayloadAction<Prefs>) => action.payload,
+  },
+});
+
+export const { setMastery } = masterySlice.actions;
+export const { setAttempts } = attemptsSlice.actions;
+export const { setXp } = xpSlice.actions;
+export const { setPrefs } = prefsSlice.actions;
+
+export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, RootState, SaveManager, AnyAction>;
+
+export function createAppStore(manager: SaveManager) {
+  const store = configureStore({
+    reducer: {
+      mastery: masterySlice.reducer,
+      attempts: attemptsSlice.reducer,
+      xp: xpSlice.reducer,
+      prefs: prefsSlice.reducer,
+    },
+    preloadedState: {
+      mastery: manager.mastery,
+      attempts: manager.attempts,
+      xp: manager.xp,
+      prefs: manager.prefs,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ thunk: { extraArgument: manager } }),
+  });
+  return store;
+}
+
+export type AppStore = ReturnType<typeof createAppStore>;
+export type AppDispatch = AppStore['dispatch'];
+
+export const awardXpAndSave = (delta: number, source: string, ts: Date = new Date()): AppThunk<Promise<void>> =>
+  async (dispatch, _getState, manager) => {
+    awardXp(manager.xp, manager.prefs, delta, source, ts);
+    dispatch(setXp(manager.xp));
+    dispatch(setPrefs(manager.prefs));
+    await manager.autosave();
+  };
+
+export const updateMastery = (skill: SkillMeta, grade: number, totalQuestions: number, now: Date = new Date()): AppThunk =>
+  (dispatch, _getState, manager) => {
+    updateMasteryFn(manager.mastery.ass, skill, grade, totalQuestions, now);
+    dispatch(setMastery(manager.mastery));
+  };
+
+export const autosave = (): AppThunk<Promise<void>> =>
+  async (_dispatch, _getState, manager) => {
+    await manager.autosave();
+  };
+


### PR DESCRIPTION
## Summary
- add Redux Toolkit store setup with slices for mastery, attempts, xp and prefs
- expose thunks for awardXpAndSave, updateMastery, and autosave
- initialize SaveManager in `main.tsx` and provide Redux store

## Testing
- `npm test`