### PR TITLE
Implement Tauri FS commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,105 @@
+use serde::{Serialize, Deserialize};
+use serde_json;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+#[tauri::command]
+fn read_text(path: String) -> tauri::Result<String> {
+    Ok(fs::read_to_string(path)?)
+}
+
+#[tauri::command]
+fn write_text(path: String, content: String) -> tauri::Result<()> {
+    if let Some(parent) = Path::new(&path).parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct IndexData {
+    dist: HashMap<String, HashMap<String, u32>>,
+    as_count: HashMap<String, usize>,
+}
+
+fn floyd_warshall(nodes: &[String], edges: &[(String, String)]) -> HashMap<String, HashMap<String, u32>> {
+    let n = nodes.len();
+    let mut index = HashMap::new();
+    for (i, n) in nodes.iter().enumerate() { index.insert(n.clone(), i); }
+    const INF: u32 = u32::MAX / 2;
+    let mut dist = vec![vec![INF; n]; n];
+    for i in 0..n { dist[i][i] = 0; }
+    for (a,b) in edges {
+        if let (Some(&i), Some(&j)) = (index.get(a), index.get(b)) {
+            dist[i][j] = 1;
+            dist[j][i] = 1;
+        }
+    }
+    for k in 0..n {
+        for i in 0..n {
+            for j in 0..n {
+                let nd = dist[i][k].saturating_add(dist[k][j]);
+                if nd < dist[i][j] { dist[i][j] = nd; }
+            }
+        }
+    }
+    let mut result = HashMap::new();
+    for i in 0..n {
+        let mut row = HashMap::new();
+        for j in 0..n {
+            if dist[i][j] < INF { row.insert(nodes[j].clone(), dist[i][j]); }
+        }
+        result.insert(nodes[i].clone(), row);
+    }
+    result
+}
+
+#[tauri::command]
+fn build_index(course_dirs: Vec<String>) -> tauri::Result<IndexData> {
+    let mut edges: Vec<(String,String)> = Vec::new();
+    let mut as_count: HashMap<String, usize> = HashMap::new();
+    let mut nodes: HashSet<String> = HashSet::new();
+
+    for dir in course_dirs {
+        let topics_dir = Path::new(&dir).join("topics");
+        if topics_dir.exists() {
+            for entry in fs::read_dir(&topics_dir)? {
+                let path = entry?.path();
+                let txt = fs::read_to_string(&path)?;
+                let data: serde_json::Value = serde_json::from_str(&txt)?;
+                if let (Some(id), Some(ass)) = (data.get("id"), data.get("ass")) {
+                    if let (Some(id_s), Some(arr)) = (id.as_str(), ass.as_array()) {
+                        as_count.insert(id_s.to_string(), arr.len());
+                    }
+                }
+            }
+        }
+
+        let edges_file = Path::new(&dir).join("edges.csv");
+        if edges_file.exists() {
+            let text = fs::read_to_string(edges_file)?;
+            for line in text.lines().skip(1) {
+                let mut parts = line.split(',');
+                if let (Some(src), Some(dst)) = (parts.next(), parts.next()) {
+                    edges.push((src.to_string(), dst.to_string()));
+                    nodes.insert(src.to_string());
+                    nodes.insert(dst.to_string());
+                }
+            }
+        }
+    }
+
+    let node_list: Vec<String> = nodes.into_iter().collect();
+    let dist = floyd_warshall(&node_list, &edges);
+    Ok(IndexData { dist, as_count })
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![read_text, write_text, build_index])
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,5 +34,6 @@
       "icons/icon.ico"
     ],
     "useLocalToolsDir": true
-  }
+  },
+  "commands": ["read_text", "write_text", "build_index"]
 }

--- a/src/indexBuilder.ts
+++ b/src/indexBuilder.ts
@@ -41,8 +41,9 @@ export function floydWarshall(nodes: string[], edges: Array<[string, string]>): 
   return result
 }
 
-import { promises as fs } from 'fs'
 import path from 'path'
+import { readText, writeText } from './tauriFs'
+import { promises as fs } from 'fs'
 
 export interface TopicEntry {
   id: string
@@ -54,8 +55,10 @@ export async function loadTopics(coursePath: string): Promise<TopicEntry[]> {
   const dir = path.join(coursePath, 'topics')
   const files = await fs.readdir(dir)
   const topics: TopicEntry[] = []
+  const isTauri = typeof window !== 'undefined' && '__TAURI__' in window
   for (const f of files) {
-    const txt = await fs.readFile(path.join(dir, f), 'utf8')
+    const p = path.join(dir, f)
+    const txt = isTauri ? await readText(p) : await fs.readFile(p, 'utf8')
     topics.push(JSON.parse(txt))
   }
   return topics
@@ -82,7 +85,8 @@ export async function loadSkills(coursePath: string): Promise<Record<string, Ski
 
 export async function loadEdges(coursePath: string): Promise<Edge[]> {
   const file = path.join(coursePath, 'edges.csv')
-  const text = await fs.readFile(file, 'utf8')
+  const isTauri = typeof window !== 'undefined' && '__TAURI__' in window
+  const text = isTauri ? await readText(file) : await fs.readFile(file, 'utf8')
   const lines = text.trim().split(/\r?\n/).slice(1)
   return lines.map((line) => {
     const [src, dst, weight] = line.split(',')
@@ -95,7 +99,7 @@ export interface IndexData {
   asCount: Record<string, number>
 }
 
-export async function buildIndex(courseDirs: string[], outFile: string): Promise<IndexData> {
+async function buildIndexLocal(courseDirs: string[], outFile: string): Promise<IndexData> {
   const edges: Array<[string, string]> = []
   const asCount: Record<string, number> = {}
   const nodes = new Set<string>()
@@ -116,4 +120,15 @@ export async function buildIndex(courseDirs: string[], outFile: string): Promise
   await fs.mkdir(path.dirname(outFile), { recursive: true })
   await fs.writeFile(outFile, JSON.stringify({ dist, asCount }, null, 2))
   return { dist, asCount }
+}
+
+export async function buildIndex(courseDirs: string[], outFile: string): Promise<IndexData> {
+  const isTauri = typeof window !== 'undefined' && '__TAURI__' in window
+  if (isTauri) {
+    const { invoke } = await import('@tauri-apps/api/core')
+    const index = await invoke<IndexData>('build_index', { courseDirs })
+    await writeText(outFile, JSON.stringify(index, null, 2))
+    return index
+  }
+  return buildIndexLocal(courseDirs, outFile)
 }

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import { existsSync } from 'fs'
+import { readText } from './tauriFs'
 
 /**
  * Atomically write data to a file using a temporary .tmp file then rename.
@@ -24,6 +25,6 @@ export async function readJsonWithRecovery<T>(path: string): Promise<T> {
   if (existsSync(tmp) && !existsSync(path)) {
     await fs.rename(tmp, path)
   }
-  const text = await fs.readFile(path, 'utf8')
+  const text = await readText(path)
   return JSON.parse(text) as T
 }

--- a/src/tauriFs.ts
+++ b/src/tauriFs.ts
@@ -1,0 +1,25 @@
+const isTauriEnv = typeof window !== 'undefined' && '__TAURI__' in window
+
+export function isTauri(): boolean {
+  return isTauriEnv
+}
+
+export async function readText(path: string): Promise<string> {
+  if (isTauriEnv) {
+    const { invoke } = await import('@tauri-apps/api/core')
+    return invoke<string>('read_text', { path })
+  } else {
+    const { readFile } = await import('fs/promises')
+    return readFile(path, 'utf8')
+  }
+}
+
+export async function writeText(path: string, content: string): Promise<void> {
+  if (isTauriEnv) {
+    const { invoke } = await import('@tauri-apps/api/core')
+    await invoke('write_text', { path, content })
+  } else {
+    const { writeFile } = await import('fs/promises')
+    await writeFile(path, content)
+  }
+}


### PR DESCRIPTION
## Summary
- add Rust commands to read/write text files and build the graph index
- register new commands in `tauri.conf.json`
- add `tauriFs.ts` utility using `@tauri-apps/api` invoke
- update persistence, save manager and index builder to use Tauri commands when available

## Testing
- `npm test`