### PR TITLE
Implement boot sequence with index caching

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,14 @@
+use std::fs;
+
+#[tauri::command]
+async fn read_text_file(path: String) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![read_text_file])
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/src/boot.test.ts
+++ b/src/boot.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { boot } from './boot'
+import { store, setIndex } from './store'
+import * as indexBuilder from './indexBuilder'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const repoRoot = process.cwd()
+
+async function makeTempRoot() {
+  return await fs.mkdtemp(path.join(tmpdir(), 'boot-'))
+}
+
+async function writeCourses(file: string) {
+  const content = {
+    format: 'Courses-v1',
+    courses: [{ id: 'EA', name: 'EA', path: path.join(repoRoot, 'course/ea') }],
+  }
+  await fs.writeFile(file, JSON.stringify(content))
+}
+
+describe('boot', () => {
+  let cwd: string
+  beforeEach(() => {
+    cwd = process.cwd()
+  })
+  afterEach(() => {
+    process.chdir(cwd)
+    store.dispatch(setIndex({ dist: {}, asCount: {} }))
+    vi.restoreAllMocks()
+  })
+
+  it('builds index when missing', async () => {
+    const dir = await makeTempRoot()
+    await writeCourses(path.join(dir, 'courses.json'))
+    const { invoke } = await import('@tauri-apps/api/core')
+    ;(invoke as any).mockResolvedValue(await fs.readFile(path.join(dir, 'courses.json'), 'utf8'))
+    process.chdir(dir)
+    await boot()
+    const state = store.getState()
+    expect(Object.keys(state.asCount).length).toBeGreaterThan(0)
+    const files = await fs.readdir(path.join(dir, '.cache'))
+    expect(files).toContain('index.json')
+  })
+
+  it('uses cached index when up to date', async () => {
+    const dir = await makeTempRoot()
+    await fs.mkdir(path.join(dir, '.cache'))
+    const indexPath = path.join(dir, '.cache', 'index.json')
+    const data = { dist: { A: { B: 1 } }, asCount: { T: 1 } }
+    await fs.writeFile(indexPath, JSON.stringify(data))
+    const mtime = new Date(Date.now() + 1000)
+    await fs.utimes(indexPath, mtime, mtime)
+    await writeCourses(path.join(dir, 'courses.json'))
+    const { invoke } = await import('@tauri-apps/api/core')
+    ;(invoke as any).mockResolvedValue(await fs.readFile(path.join(dir, 'courses.json'), 'utf8'))
+    const spy = vi.spyOn(indexBuilder, 'buildIndex')
+    process.chdir(dir)
+    await boot()
+    expect(spy).not.toHaveBeenCalled()
+    const state = store.getState()
+    expect(state.asCount.T).toBe(1)
+  })
+})

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -1,0 +1,70 @@
+import { invoke } from '@tauri-apps/api/core'
+import { promises as fs, existsSync } from 'fs'
+import path from 'path'
+import { loadTopics, loadSkills, loadEdges, buildIndex, IndexData } from './indexBuilder'
+import { store, setIndex } from './store'
+
+interface CourseEntry {
+  id: string
+  name: string
+  path: string
+}
+
+interface CourseRegistry {
+  format: string
+  courses: CourseEntry[]
+}
+
+async function courseTimestamp(dir: string): Promise<number> {
+  let latest = 0
+  const tdir = path.join(dir, 'topics')
+  const sdir = path.join(dir, 'skills')
+  const topicFiles = await fs.readdir(tdir)
+  for (const f of topicFiles) {
+    const stat = await fs.stat(path.join(tdir, f))
+    if (stat.mtimeMs > latest) latest = stat.mtimeMs
+  }
+  const skillFiles = await fs.readdir(sdir)
+  for (const f of skillFiles) {
+    const stat = await fs.stat(path.join(sdir, f))
+    if (stat.mtimeMs > latest) latest = stat.mtimeMs
+  }
+  const estat = await fs.stat(path.join(dir, 'edges.csv'))
+  if (estat.mtimeMs > latest) latest = estat.mtimeMs
+  return latest
+}
+
+export async function boot(): Promise<void> {
+  const root = process.cwd()
+  const coursesFile = path.join(root, 'courses.json')
+  const text: string = await invoke('read_text_file', { path: coursesFile })
+  const registry = JSON.parse(text) as CourseRegistry
+  const courseDirs = registry.courses.map(c => path.isAbsolute(c.path) ? c.path : path.join(root, c.path))
+
+  for (const dir of courseDirs) {
+    await loadTopics(dir)
+    await loadSkills(dir)
+    await loadEdges(dir)
+  }
+
+  const indexPath = path.join(root, '.cache', 'index.json')
+  let indexData: IndexData
+  let rebuild = true
+  if (existsSync(indexPath)) {
+    const istat = await fs.stat(indexPath)
+    let latest = (await fs.stat(coursesFile)).mtimeMs
+    for (const dir of courseDirs) {
+      const ts = await courseTimestamp(dir)
+      if (ts > latest) latest = ts
+    }
+    rebuild = latest > istat.mtimeMs
+    if (!rebuild) {
+      const saved = await fs.readFile(indexPath, 'utf8')
+      indexData = JSON.parse(saved) as IndexData
+    }
+  }
+  if (rebuild) {
+    indexData = await buildIndex(courseDirs, indexPath)
+  }
+  store.dispatch(setIndex(indexData!))
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,14 +4,21 @@ import './index.css';
 import App from './App.tsx';
 import { I18nProvider } from './i18n.tsx';
 import { ThemeProvider } from './theme.tsx';
+import { Provider } from 'react-redux'
+import { store } from './store'
+import { boot } from './boot'
+
+boot()
 import 'mathjax/es5/tex-mml-chtml.js';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <I18nProvider>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </I18nProvider>
+    <Provider store={store}>
+      <I18nProvider>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </I18nProvider>
+    </Provider>
   </StrictMode>,
 );

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,45 @@
+import type { DistMatrix } from './indexBuilder'
+
+export interface IndexState {
+  dist: DistMatrix
+  asCount: Record<string, number>
+}
+
+const initialState: IndexState = { dist: {}, asCount: {} }
+
+type Action = { type: 'setIndex'; payload: IndexState } | { type: '__INIT__' }
+
+function reducer(state: IndexState = initialState, action: Action): IndexState {
+  switch (action.type) {
+    case 'setIndex':
+      return { dist: action.payload.dist, asCount: action.payload.asCount }
+    default:
+      return state
+  }
+}
+
+export function setIndex(data: IndexState): Action {
+  return { type: 'setIndex', payload: data }
+}
+
+export function createStore() {
+  let state = reducer(undefined, { type: '__INIT__' })
+  const listeners = new Set<() => void>()
+  return {
+    dispatch(action: Action) {
+      state = reducer(state, action)
+      listeners.forEach(l => l())
+    },
+    getState() {
+      return state
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+}
+
+export const store = createStore()
+export type AppDispatch = typeof store.dispatch
+export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
## Summary
- add Redux-like store for application data
- load courses and build index at startup via new `boot` module
- expose `read_text_file` command in Tauri backend
- update main render to provide store and invoke boot
- unit test boot logic for cache rebuild behavior

## Testing
- `npm test`