### PR TITLE
Implement simple schedule module and update learning flow

### DIFF
--- a/src/schedule.test.ts
+++ b/src/schedule.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { runScheduler, getQueue } from './schedule'
+import { MasteryEntry } from './updateMastery'
+import { Prefs, XpLog } from './awardXp'
+import { DistMatrix, SkillMeta } from './scheduler'
+
+describe('schedule module', () => {
+  it('populates queue', () => {
+    const skills: Record<string, SkillMeta> = { A: { id: 'A', topic: 'T1' } }
+    const mastery: Record<string, MasteryEntry> = {
+      A: {
+        status: 'in_progress', s: 0, d: 0, r: 0, l: 0,
+        next_due: '2025-01-01T00:00:00Z', next_q_index: 0
+      }
+    }
+    const prefs: Prefs = { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+    const xp: XpLog = { format: 'XP-v1', log: [] }
+    const dist: DistMatrix = {}
+    runScheduler(skills, mastery, prefs, xp, dist, new Date('2025-01-02T00:00:00Z'))
+    const q = getQueue()
+    expect(q.length).toBe(1)
+    expect(q[0].id).toBe('A')
+  })
+})

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,0 +1,32 @@
+import { Candidate, generateCandidates, DistMatrix, SkillMeta } from './scheduler'
+import { MasteryEntry } from './updateMastery'
+import { Prefs, XpLog } from './awardXp'
+
+interface ScheduleState {
+  queue: Candidate[]
+}
+
+const state: ScheduleState = { queue: [] }
+
+export function getQueue(): Candidate[] {
+  return state.queue
+}
+
+export function popTask(): Candidate | undefined {
+  return state.queue.shift()
+}
+
+export function setQueue(q: Candidate[]): void {
+  state.queue = q
+}
+
+export function runScheduler(
+  skills: Record<string, SkillMeta>,
+  mastery: Record<string, MasteryEntry>,
+  prefs: Prefs,
+  xp: XpLog,
+  dist: DistMatrix,
+  now: Date = new Date(),
+): void {
+  state.queue = generateCandidates(skills, mastery, prefs, xp, dist, now)
+}

--- a/src/screens/Learning.tsx
+++ b/src/screens/Learning.tsx
@@ -1,17 +1,119 @@
-import React from 'react';
-import MixedQuizPlayer from '../components/MixedQuizPlayer';
+import React, { useEffect, useRef, useState } from 'react'
+import LessonFlow, { LessonQuestion } from '../components/LessonFlow'
+import MixedQuizPlayer from '../components/MixedQuizPlayer'
+import { getQueue, popTask, runScheduler } from '../schedule'
+import { loadMarkdown, loadYaml } from '../loaders'
+import { assembleMixedQuiz, MixedQuestion } from '../mixedQuiz'
+import { updateMastery, MasteryEntry, SkillMeta } from '../updateMastery'
+import { awardXpAndSave, Prefs, XpLog } from '../awardXp'
+import * as YAML from 'js-yaml'
 
-const TOTAL = 15;
+const TOTAL = 15
 
 export default function Learning() {
-  const current = 1;
+  const queue = getQueue()
+
+  // simple in-memory state for demo purposes
+  const mastery = useRef<Record<string, MasteryEntry>>({
+    ['EA:' + 'A' + 'S001']: {
+      status: 'unseen',
+      s: 0,
+      d: 0,
+      r: 0,
+      l: 0,
+      next_due: new Date().toISOString(),
+      next_q_index: 0
+    }
+  }).current
+
+  const skills: Record<string, SkillMeta> = {
+    ['EA:' + 'A' + 'S001']: { id: 'EA:' + 'A' + 'S001', topic: 'EA:T001' }
+  }
+
+  const prefs = useRef<Prefs>({
+    format: 'Prefs-v2',
+    profile: 'save',
+    xp_since_mixed_quiz: 0,
+    last_as: null,
+    ui_theme: 'default'
+  }).current
+
+  const xp = useRef<XpLog>({ format: 'XP-v1', log: [] }).current
+  const dist = {}
+
+  useEffect(() => {
+    runScheduler(skills, mastery, prefs, xp, dist)
+  }, [])
+
+  const task = queue[0]
+
+  const [lesson, setLesson] = useState<{
+    exposition: string
+    question: LessonQuestion
+  } | null>(null)
+  const [quiz, setQuiz] = useState<MixedQuestion[] | null>(null)
+
+  useEffect(() => {
+    if (!task) return
+    async function load() {
+      if (task.kind === 'mixed_quiz') {
+        const yamlText = await loadYaml('course/ea/as_questions/' + 'A' + 'S001.yaml')
+        const data: any = YAML.load(yamlText)
+        const pools = { ['EA:' + 'A' + 'S001']: { pool: data.pool } }
+        setQuiz(assembleMixedQuiz(mastery, pools, xp, TOTAL))
+      } else {
+        const [courseId, skillId] = task.id.split(':')
+        const md = await loadMarkdown(`course/${courseId}/as_md/${skillId}.md`)
+        const yamlText = await loadYaml(`course/${courseId}/as_questions/${skillId}.yaml`)
+        const data: any = YAML.load(yamlText)
+        setLesson({ exposition: md, question: data.pool[0] })
+      }
+    }
+    load()
+  }, [task])
+
+  const handleGrade = async (grade: number) => {
+    if (!task || task.kind === 'mixed_quiz' || !lesson) return
+    updateMastery(mastery, skills[task.id], grade, 1)
+    await awardXpAndSave({ xp, prefs, autosave: async () => {} } as any, 10, `${task.id}_q1`)
+    prefs.last_as = task.id
+    popTask()
+    runScheduler(skills, mastery, prefs, xp, dist)
+  }
+
+  if (!task) {
+    return (
+      <div className="p-4">
+        <h2 className="text-2xl font-bold mb-4">Learning</h2>
+        <p>No tasks available.</p>
+      </div>
+    )
+  }
+
+  if (task.kind === 'mixed_quiz' && quiz) {
+    return (
+      <div className="p-4">
+        <h2 className="text-2xl font-bold mb-4">Learning</h2>
+        <MixedQuizPlayer current={1} total={quiz.length}>
+          <p>Quiz in progress...</p>
+        </MixedQuizPlayer>
+      </div>
+    )
+  }
+
+  if (lesson) {
+    return (
+      <div className="p-4">
+        <h2 className="text-2xl font-bold mb-4">Learning</h2>
+        <LessonFlow exposition={lesson.exposition} question={lesson.question} onGrade={handleGrade} />
+      </div>
+    )
+  }
+
   return (
     <div className="p-4">
       <h2 className="text-2xl font-bold mb-4">Learning</h2>
-      <p>Start your next Skill here.</p>
-      <MixedQuizPlayer current={current} total={TOTAL}>
-        <p>Question text goes here.</p>
-      </MixedQuizPlayer>
+      <p>Loading...</p>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- add standalone `schedule` module with queue state and scheduler integration
- update `Learning` screen to use new schedule logic
- provide tests for scheduler

## Testing
- `npm test`