### PR TITLE
Add Redux-style store and integrate navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import './App.css';
 import { useI18n } from './i18n.tsx';
 import { useTheme } from './theme.tsx';
@@ -8,14 +8,15 @@ import Learning from './screens/Learning.tsx';
 import Progress from './screens/Progress.tsx';
 import Library from './screens/Library.tsx';
 import Settings from './screens/Settings.tsx';
-
-type Screen = 'home' | 'learning' | 'progress' | 'library' | 'settings';
+import { RootState, Screen } from './store';
+import type { AppDispatch } from './store';
 
 export default function App() {
-  const [screen, setScreen] = useState<Screen>('home');
-  const { toggle } = useTheme();
-  const strings = useI18n();
-  useExternalLinks();
+  const dispatch: AppDispatch = useDispatch()
+  const screen = useSelector((state: RootState) => state.ui.screen)
+  const { toggle } = useTheme()
+  const strings = useI18n()
+  useExternalLinks()
 
   const renderScreen = () => {
     switch (screen) {
@@ -39,11 +40,11 @@ export default function App() {
       </header>
       <main style={{ flexGrow: 1 }}>{renderScreen()}</main>
       <nav style={{ borderTop: '1px solid #ccc', display: 'flex', justifyContent: 'space-around', padding: '0.5rem', background: '#f0f0f0' }}>
-        <button onClick={() => setScreen('home')} style={{ fontWeight: screen === 'home' ? 'bold' as const : 'normal' }}>{strings.home}</button>
-        <button onClick={() => setScreen('learning')} style={{ fontWeight: screen === 'learning' ? 'bold' as const : 'normal' }}>{strings.learning}</button>
-        <button onClick={() => setScreen('progress')} style={{ fontWeight: screen === 'progress' ? 'bold' as const : 'normal' }}>{strings.progress}</button>
-        <button onClick={() => setScreen('library')} style={{ fontWeight: screen === 'library' ? 'bold' as const : 'normal' }}>{strings.library}</button>
-        <button onClick={() => setScreen('settings')} style={{ fontWeight: screen === 'settings' ? 'bold' as const : 'normal' }}>{strings.settings}</button>
+        <button onClick={() => dispatch({ type: 'ui/setScreen', payload: 'home' as Screen })} style={{ fontWeight: screen === 'home' ? 'bold' as const : 'normal' }}>{strings.home}</button>
+        <button onClick={() => dispatch({ type: 'ui/setScreen', payload: 'learning' as Screen })} style={{ fontWeight: screen === 'learning' ? 'bold' as const : 'normal' }}>{strings.learning}</button>
+        <button onClick={() => dispatch({ type: 'ui/setScreen', payload: 'progress' as Screen })} style={{ fontWeight: screen === 'progress' ? 'bold' as const : 'normal' }}>{strings.progress}</button>
+        <button onClick={() => dispatch({ type: 'ui/setScreen', payload: 'library' as Screen })} style={{ fontWeight: screen === 'library' ? 'bold' as const : 'normal' }}>{strings.library}</button>
+        <button onClick={() => dispatch({ type: 'ui/setScreen', payload: 'settings' as Screen })} style={{ fontWeight: screen === 'settings' ? 'bold' as const : 'normal' }}>{strings.settings}</button>
       </nav>
       <button style={{ margin: '0.5rem' }} onClick={toggle}>{strings.toggle_dark_mode}</button>
     </div>

--- a/src/__tests__/accessibility.test.tsx
+++ b/src/__tests__/accessibility.test.tsx
@@ -2,15 +2,20 @@ import { render, screen } from '@testing-library/react'
 import App from '../App'
 import { I18nProvider } from '../i18n'
 import { ThemeProvider } from '../theme'
+import { Provider } from 'react-redux'
+import { createAppStore } from '../store'
 
 describe('accessibility', () => {
   function setup() {
+    const store = createAppStore()
     render(
-      <I18nProvider>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </I18nProvider>
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
     )
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,14 +4,18 @@ import './index.css';
 import App from './App.tsx';
 import { I18nProvider } from './i18n.tsx';
 import { ThemeProvider } from './theme.tsx';
+import { Provider } from 'react-redux';
+import { store } from './store';
 import 'mathjax/es5/tex-mml-chtml.js';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <I18nProvider>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </I18nProvider>
+    <Provider store={store}>
+      <I18nProvider>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </I18nProvider>
+    </Provider>
   </StrictMode>,
 );

--- a/src/screens/__tests__/navigation.e2e.test.tsx
+++ b/src/screens/__tests__/navigation.e2e.test.tsx
@@ -2,15 +2,20 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../../App'
 import { I18nProvider } from '../../i18n'
 import { ThemeProvider } from '../../theme'
+import { Provider } from 'react-redux'
+import { createAppStore } from '../../store'
 
 describe('navigation between screens', () => {
   function setup() {
+    const store = createAppStore()
     render(
-      <I18nProvider>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </I18nProvider>
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
     )
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,91 @@
+import { MasteryFile, AttemptsFile } from '../saveManager'
+import { Catalog } from '../courseRegistry'
+import { SkillEntry } from '../indexBuilder'
+import { Prefs, XpLog } from '../awardXp'
+
+export type Screen = 'home' | 'learning' | 'progress' | 'library' | 'settings'
+
+export interface CoursesState {
+  catalogs: Record<string, Catalog>
+  skills: Record<string, SkillEntry>
+}
+
+export interface UserState {
+  mastery: MasteryFile | null
+  attempts: AttemptsFile | null
+  xp: XpLog | null
+  prefs: Prefs | null
+}
+
+export interface UIState {
+  screen: Screen
+  mode: string
+  task: string | null
+}
+
+export interface RootState {
+  courses: CoursesState
+  user: UserState
+  ui: UIState
+}
+
+const initialState: RootState = {
+  courses: { catalogs: {}, skills: {} },
+  user: { mastery: null, attempts: null, xp: null, prefs: null },
+  ui: { screen: 'home', mode: 'idle', task: null },
+}
+
+export type Action =
+  | { type: 'ui/setScreen'; payload: Screen }
+  | { type: 'ui/setMode'; payload: string }
+  | { type: 'ui/setTask'; payload: string | null }
+  | { type: 'user/setSave'; payload: UserState }
+  | { type: 'courses/setData'; payload: CoursesState }
+
+export function rootReducer(state: RootState = initialState, action: Action): RootState {
+  switch (action.type) {
+    case 'ui/setScreen':
+      return { ...state, ui: { ...state.ui, screen: action.payload } }
+    case 'ui/setMode':
+      return { ...state, ui: { ...state.ui, mode: action.payload } }
+    case 'ui/setTask':
+      return { ...state, ui: { ...state.ui, task: action.payload } }
+    case 'user/setSave':
+      return { ...state, user: action.payload }
+    case 'courses/setData':
+      return { ...state, courses: action.payload }
+    default:
+      return state
+  }
+}
+
+type Listener = () => void
+
+export function createAppStore(preloaded?: Partial<RootState>) {
+  let state: RootState = { ...initialState, ...preloaded }
+  const listeners: Listener[] = []
+
+  function getState() {
+    return state
+  }
+
+  function dispatch(action: Action) {
+    state = rootReducer(state, action)
+    listeners.forEach((l) => l())
+    return action
+  }
+
+  function subscribe(listener: Listener) {
+    listeners.push(listener)
+    return () => {
+      const idx = listeners.indexOf(listener)
+      if (idx >= 0) listeners.splice(idx, 1)
+    }
+  }
+
+  return { getState, dispatch, subscribe }
+}
+
+export type AppStore = ReturnType<typeof createAppStore>
+export type AppDispatch = AppStore['dispatch']
+export const store = createAppStore()


### PR DESCRIPTION
## Summary
- implement a minimal Redux-style store under `src/store`
- wire the store Provider in `main.tsx`
- use store-driven navigation in `App`
- update tests to create the store when rendering components

## Testing
- `npm test`