### PR TITLE
Add Tauri file commands and IPC wrappers

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.5.0", features = [] }
 tauri-plugin-log = "2.0.0-rc"
+dirs = "5"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,88 @@
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use tauri::command;
+
+fn persistence_dir() -> PathBuf {
+  #[cfg(target_os = "android")]
+  {
+    PathBuf::from("Android/data/com.mathacademy/files")
+  }
+  #[cfg(not(target_os = "android"))]
+  {
+    dirs::home_dir()
+      .unwrap_or_else(|| PathBuf::from("."))
+      .join(".mathacademy")
+  }
+}
+
+fn full_path(rel: &str) -> PathBuf {
+  persistence_dir().join(rel)
+}
+
+#[command]
+fn read_file(path: String) -> Result<String, String> {
+  let p = full_path(&path);
+  fs::read_to_string(p).map_err(|e| e.to_string())
+}
+
+#[command]
+fn write_file(path: String, data: String) -> Result<(), String> {
+  let p = full_path(&path);
+  if let Some(parent) = p.parent() {
+    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+  }
+  let tmp = p.with_extension("tmp");
+  {
+    let mut f = File::create(&tmp).map_err(|e| e.to_string())?;
+    f.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
+    f.sync_all().map_err(|e| e.to_string())?;
+  }
+  fs::rename(tmp, p).map_err(|e| e.to_string())
+}
+
+#[command]
+fn log_error(msg: String) -> Result<(), String> {
+  let p = persistence_dir().join("logs/error.log");
+  if let Some(parent) = p.parent() {
+    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+  }
+  let mut f = fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .open(&p)
+    .map_err(|e| e.to_string())?;
+  writeln!(f, "{}", msg).map_err(|e| e.to_string())
+}
+
+#[command]
+fn log_debug(msg: String) -> Result<(), String> {
+  if !cfg!(debug_assertions) {
+    return Ok(());
+  }
+  let p = persistence_dir().join("logs/debug.log");
+  if let Some(parent) = p.parent() {
+    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+  }
+  let mut f = fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .open(&p)
+    .map_err(|e| e.to_string())?;
+  writeln!(f, "{}", msg).map_err(|e| e.to_string())
+}
+
+#[command]
+fn get_schedule() -> Result<String, String> {
+  // placeholder until scheduler implemented in Rust
+  Ok("[]".into())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![read_file, write_file, log_error, log_debug, get_schedule])
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,0 +1,12 @@
+import { invoke } from '@tauri-apps/api/core'
+import { logError } from './logger'
+
+export async function getSchedule(): Promise<any> {
+  try {
+    const txt: string = await invoke('get_schedule')
+    return JSON.parse(txt)
+  } catch (e) {
+    await logError(String(e))
+    throw e
+  }
+}

--- a/src/courseRegistry.ts
+++ b/src/courseRegistry.ts
@@ -1,4 +1,6 @@
 import { promises as fs } from 'fs'
+import { invoke } from '@tauri-apps/api/core'
+import { logError } from './logger'
 import path from 'path'
 
 export interface CourseEntry {
@@ -16,7 +18,17 @@ export interface CourseRegistry {
  * Load the global course registry from a JSON file.
  */
 export async function loadCourseRegistry(file: string): Promise<CourseEntry[]> {
-  const text = await fs.readFile(file, 'utf8')
+  let text: string
+  if (typeof window !== 'undefined' && '__TAURI__' in window) {
+    try {
+      text = await invoke('read_file', { path: file })
+    } catch (e) {
+      await logError(String(e))
+      throw e
+    }
+  } else {
+    text = await fs.readFile(file, 'utf8')
+  }
   const data = JSON.parse(text) as CourseRegistry
   if (data.format !== 'Courses-v1' || !Array.isArray(data.courses)) {
     throw new Error('Invalid course registry')
@@ -35,7 +47,17 @@ export interface Catalog {
  * Load a course catalog file.
  */
 export async function loadCatalog(file: string): Promise<Catalog> {
-  const text = await fs.readFile(file, 'utf8')
+  let text: string
+  if (typeof window !== 'undefined' && '__TAURI__' in window) {
+    try {
+      text = await invoke('read_file', { path: file })
+    } catch (e) {
+      await logError(String(e))
+      throw e
+    }
+  } else {
+    text = await fs.readFile(file, 'utf8')
+  }
   const data = JSON.parse(text) as Catalog
   if (data.format !== 'Catalog-v1') {
     throw new Error('Invalid catalog')

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import path from 'path'
+import { invoke } from '@tauri-apps/api/core'
 
 const ROTATIONS = 3
 
@@ -47,11 +48,23 @@ async function append(file: string, msg: string) {
   await fs.appendFile(file, msg + '\n')
 }
 
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI__' in window
+}
+
 export async function logError(msg: string) {
-  await append(path.join(logDir(), 'error.log'), msg)
+  if (isTauri()) {
+    await invoke('log_error', { msg })
+  } else {
+    await append(path.join(logDir(), 'error.log'), msg)
+  }
 }
 
 export async function logDebug(msg: string) {
   if (process.env.NODE_ENV === 'production') return
-  await append(path.join(logDir(), 'debug.log'), msg)
+  if (isTauri()) {
+    await invoke('log_debug', { msg })
+  } else {
+    await append(path.join(logDir(), 'debug.log'), msg)
+  }
 }

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,29 +1,50 @@
 import { promises as fs } from 'fs'
 import { existsSync } from 'fs'
+import { invoke } from '@tauri-apps/api/core'
+import { logError } from './logger'
 
 /**
  * Atomically write data to a file using a temporary .tmp file then rename.
  */
 export async function atomicWriteFile(path: string, data: string | Buffer): Promise<void> {
-  const tmp = path + '.tmp'
-  const handle = await fs.open(tmp, 'w')
-  try {
-    await handle.writeFile(data)
-    await handle.sync()
-  } finally {
-    await handle.close()
+  if (typeof window !== 'undefined' && '__TAURI__' in window) {
+    try {
+      await invoke('write_file', { path, data: data.toString() })
+    } catch (e) {
+      await logError(String(e))
+      throw e
+    }
+  } else {
+    const tmp = path + '.tmp'
+    const handle = await fs.open(tmp, 'w')
+    try {
+      await handle.writeFile(data)
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await fs.rename(tmp, path)
   }
-  await fs.rename(tmp, path)
 }
 
 /**
  * Read a JSON file, recovering from a leftover .tmp if present.
  */
 export async function readJsonWithRecovery<T>(path: string): Promise<T> {
-  const tmp = path + '.tmp'
-  if (existsSync(tmp) && !existsSync(path)) {
-    await fs.rename(tmp, path)
+  if (typeof window !== 'undefined' && '__TAURI__' in window) {
+    try {
+      const text: string = await invoke('read_file', { path })
+      return JSON.parse(text) as T
+    } catch (e) {
+      await logError(String(e))
+      throw e
+    }
+  } else {
+    const tmp = path + '.tmp'
+    if (existsSync(tmp) && !existsSync(path)) {
+      await fs.rename(tmp, path)
+    }
+    const text = await fs.readFile(path, 'utf8')
+    return JSON.parse(text) as T
   }
-  const text = await fs.readFile(path, 'utf8')
-  return JSON.parse(text) as T
 }


### PR DESCRIPTION
## Summary
- expose file read/write, logging, and schedule commands in the Tauri backend
- map persistence path based on platform
- provide IPC wrappers for persistence and logging
- replace direct fs usage with IPC in courseRegistry and persistence utilities

## Testing
- `npm test`