### PR TITLE
Implement course initialization and index caching

### DIFF
--- a/src/indexBuilder.test.ts
+++ b/src/indexBuilder.test.ts
@@ -26,5 +26,6 @@ describe('buildIndex', async () => {
     expect(index.dist[skillA][skillB]).toBeGreaterThan(0)
     const saved = JSON.parse(await fs.readFile(outFile, 'utf8'))
     expect(saved.dist[skillA][skillB]).toBe(index.dist[skillA][skillB])
+    expect(saved.courses).toEqual([courseDir])
   })
 })

--- a/src/indexBuilder.ts
+++ b/src/indexBuilder.ts
@@ -93,6 +93,7 @@ export async function loadEdges(coursePath: string): Promise<Edge[]> {
 export interface IndexData {
   dist: DistMatrix
   asCount: Record<string, number>
+  courses: string[]
 }
 
 export async function buildIndex(courseDirs: string[], outFile: string): Promise<IndexData> {
@@ -114,6 +115,6 @@ export async function buildIndex(courseDirs: string[], outFile: string): Promise
   const nodeList = Array.from(nodes)
   const dist = floydWarshall(nodeList, edges)
   await fs.mkdir(path.dirname(outFile), { recursive: true })
-  await fs.writeFile(outFile, JSON.stringify({ dist, asCount }, null, 2))
-  return { dist, asCount }
+  await fs.writeFile(outFile, JSON.stringify({ dist, asCount, courses: courseDirs }, null, 2))
+  return { dist, asCount, courses: courseDirs }
 }

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { init } from './init'
+import { createAppStore } from './store'
+
+const root = process.cwd()
+
+describe('init', () => {
+  it('rebuilds index when topic files change', async () => {
+    const tmp = await fs.mkdtemp(path.join(tmpdir(), 'init-'))
+    await fs.mkdir(path.join(tmp, 'course'), { recursive: true })
+    await fs.cp(path.join(root, 'course/ea'), path.join(tmp, 'course/ea'), { recursive: true })
+    await fs.writeFile(
+      path.join(tmp, 'courses.json'),
+      JSON.stringify({ format: 'Courses-v1', courses: [{ id: 'EA', name: 'EA', path: 'course/ea/' }] })
+    )
+    const store = createAppStore()
+
+    await init(store, tmp)
+    const indexPath = path.join(tmp, '.cache/index.db')
+    const m1 = (await fs.stat(indexPath)).mtimeMs
+
+    await init(store, tmp)
+    const m2 = (await fs.stat(indexPath)).mtimeMs
+    expect(m2).toBe(m1)
+
+    const topic = path.join(tmp, 'course/ea/topics/T001.json')
+    const txt = await fs.readFile(topic, 'utf8')
+    await fs.writeFile(topic, txt)
+
+    await init(store, tmp)
+    const m3 = (await fs.stat(indexPath)).mtimeMs
+    expect(m3).toBeGreaterThan(m2)
+  })
+})

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,63 @@
+import path from 'path'
+import { promises as fs } from 'fs'
+import { loadCourseRegistry, loadCatalog } from './courseRegistry'
+import { loadSkills, buildIndex, SkillEntry, IndexData } from './indexBuilder'
+import type { AppStore, CoursesState } from './store'
+
+async function newestMTime(dir: string): Promise<number> {
+  const files = await fs.readdir(dir)
+  let m = 0
+  for (const f of files) {
+    const stat = await fs.stat(path.join(dir, f))
+    if (stat.mtimeMs > m) m = stat.mtimeMs
+  }
+  return m
+}
+
+async function needsRebuild(indexPath: string, courseDirs: string[]): Promise<boolean> {
+  try {
+    const stat = await fs.stat(indexPath)
+    const data = JSON.parse(await fs.readFile(indexPath, 'utf8')) as { courses?: string[] }
+    if (!Array.isArray(data.courses)) return true
+    if (data.courses.join('|') !== courseDirs.join('|')) return true
+    const indexTime = stat.mtimeMs
+    for (const dir of courseDirs) {
+      const m = await newestMTime(path.join(dir, 'topics'))
+      if (m > indexTime) return true
+    }
+    return false
+  } catch {
+    return true
+  }
+}
+
+export interface InitResult {
+  catalogs: Record<string, any>
+  skills: Record<string, SkillEntry>
+  index: IndexData
+}
+
+export async function init(store: AppStore, rootDir = process.cwd()): Promise<InitResult> {
+  const registryFile = path.join(rootDir, 'courses.json')
+  const courses = await loadCourseRegistry(registryFile)
+  const catalogs: Record<string, any> = {}
+  const skills: Record<string, SkillEntry> = {}
+  const dirs: string[] = []
+
+  for (const c of courses) {
+    const dir = path.join(rootDir, c.path)
+    dirs.push(dir)
+    const cat = await loadCatalog(path.join(dir, 'catalog.json'))
+    catalogs[c.id] = cat
+    Object.assign(skills, await loadSkills(dir))
+  }
+
+  const indexPath = path.join(rootDir, '.cache', 'index.db')
+  const rebuild = await needsRebuild(indexPath, dirs)
+  const index = rebuild ? await buildIndex(dirs, indexPath) : JSON.parse(await fs.readFile(indexPath, 'utf8')) as IndexData
+
+  const payload: CoursesState = { catalogs, skills }
+  store.dispatch({ type: 'courses/setData', payload })
+
+  return { catalogs, skills, index }
+}


### PR DESCRIPTION
## Summary
- add `courses` list to IndexData
- store course list when building an index
- implement new `init` module that loads courses and rebuilds indexes when needed
- test initialization and index rebuild logic
- update indexBuilder tests for course list

## Testing
- `npm test`