### PR TITLE
Implement SaveManager wiring and settings actions

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,5 +18,8 @@
   "again": "Again",
   "hard": "Hard",
   "okay": "Okay",
-  "easy": "Easy"
+  "easy": "Easy",
+  "export_progress": "Export Progress",
+  "import_progress": "Import Progress",
+  "reset_profile": "Reset Profile"
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,16 +6,19 @@ import { I18nProvider } from './i18n.tsx';
 import { ThemeProvider } from './theme.tsx';
 import { Provider } from 'react-redux';
 import { store } from './store';
+import { initSaveManager } from './saveManagerSetup';
 import 'mathjax/es5/tex-mml-chtml.js';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <Provider store={store}>
-      <I18nProvider>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </I18nProvider>
-    </Provider>
-  </StrictMode>,
-);
+initSaveManager().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
+    </StrictMode>,
+  );
+});

--- a/src/saveManager.ts
+++ b/src/saveManager.ts
@@ -30,6 +30,7 @@ export interface SaveManagerOptions {
   toast?: (msg: string) => void
   initialDelayMs?: number
   maxDelayMs?: number
+  onChange?: (state: SaveState) => void
 }
 
 export class SaveManager implements SaveState {
@@ -57,6 +58,12 @@ export class SaveManager implements SaveState {
       const handler = async (curr: Stats, prev: Stats) => {
         if (curr.mtimeMs === prev.mtimeMs) return
         assign(JSON.parse(await fs.readFile(file, 'utf8')))
+        this.options.onChange?.({
+          mastery: this.mastery,
+          attempts: this.attempts,
+          xp: this.xp,
+          prefs: this.prefs,
+        })
       }
       watchFile(file, { persistent: false, interval }, handler)
       this.watchers.push({ file, handler })
@@ -103,6 +110,12 @@ export class SaveManager implements SaveState {
     this.xp = await loadWithMigrations<XpLog>(path.join(this.dir, 'xp.json'), 'XP-v1')
     this.prefs = await loadWithMigrations<Prefs>(path.join(this.dir, 'prefs.json'), 'Prefs-v2')
     this.watch()
+    this.options.onChange?.({
+      mastery: this.mastery,
+      attempts: this.attempts,
+      xp: this.xp,
+      prefs: this.prefs,
+    })
   }
 
   private async writeAll() {

--- a/src/saveManagerSetup.ts
+++ b/src/saveManagerSetup.ts
@@ -1,0 +1,31 @@
+import path from 'path'
+import { SaveManager } from './saveManager'
+import { Prefs } from './awardXp'
+import { loadWithMigrations } from './migrations'
+import { store } from './store'
+
+export let saveManager: SaveManager
+
+export async function initSaveManager() {
+  let prefs: Prefs
+  try {
+    prefs = await loadWithMigrations<Prefs>(path.join('save', 'prefs.json'), 'Prefs-v2')
+  } catch {
+    prefs = { format: 'Prefs-v2', profile: 'save', xp_since_mixed_quiz: 0, last_as: null, ui_theme: 'default' }
+  }
+  const dir = prefs.profile
+  saveManager = new SaveManager(dir, {
+    onChange: () => {
+      store.dispatch({
+        type: 'user/setSave',
+        payload: {
+          mastery: saveManager.mastery,
+          attempts: saveManager.attempts,
+          xp: saveManager.xp,
+          prefs: saveManager.prefs,
+        },
+      })
+    },
+  })
+  await saveManager.load()
+}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,10 +1,28 @@
-import React from 'react';
+import React from 'react'
+import { useI18n } from '../i18n'
+import { saveManager } from '../saveManagerSetup'
 
 export default function Settings() {
+  const strings = useI18n()
+
+  const doExport = () => {
+    void saveManager.exportProgress('export.zip')
+  }
+
+  const doImport = () => {
+    void saveManager.importProgress('export.zip')
+  }
+
+  const doReset = () => {
+    void saveManager.resetProfile()
+  }
+
   return (
     <div className="p-4">
-      <h2 className="text-2xl font-bold mb-4">Settings</h2>
-      <p>Adjust your preferences.</p>
+      <h2 className="text-2xl font-bold mb-4">{strings.settings}</h2>
+      <button onClick={doExport}>{strings.export_progress}</button>
+      <button onClick={doImport}>{strings.import_progress}</button>
+      <button onClick={doReset}>{strings.reset_profile}</button>
     </div>
-  );
+  )
 }

--- a/src/screens/__tests__/settingsActions.test.tsx
+++ b/src/screens/__tests__/settingsActions.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Settings from '../Settings'
+import { I18nProvider } from '../../i18n'
+import { vi } from 'vitest'
+
+vi.mock('../../saveManagerSetup', () => ({
+  saveManager: {
+    exportProgress: vi.fn(),
+    importProgress: vi.fn(),
+    resetProfile: vi.fn(),
+  }
+}))
+import { saveManager } from '../../saveManagerSetup'
+
+describe('settings actions', () => {
+  it('calls SaveManager methods', () => {
+    render(
+      <I18nProvider>
+        <Settings />
+      </I18nProvider>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /export progress/i }))
+    expect(saveManager.exportProgress).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /import progress/i }))
+    expect(saveManager.importProgress).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /reset profile/i }))
+    expect(saveManager.resetProfile).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add `onChange` callback to `SaveManager` so external state can react to file changes
- provide global `saveManager` instance with initialization helper
- initialize save manager before rendering React app
- expose export/import/reset actions on Settings screen
- translate new strings in english locale
- test settings actions trigger SaveManager methods

## Testing
- `npm test`