### PR TITLE
Add SaveManager startup and settings actions

### DIFF
--- a/src/__tests__/accessibility.test.tsx
+++ b/src/__tests__/accessibility.test.tsx
@@ -4,15 +4,20 @@ import { I18nProvider } from '../i18n'
 import { ThemeProvider } from '../theme'
 import { Provider } from 'react-redux'
 import { createAppStore } from '../store'
+import { SaveManagerProvider } from '../saveContext'
+import { SaveManager } from '../saveManager'
 
 describe('accessibility', () => {
   function setup() {
     const store = createAppStore()
+    const manager = new SaveManager('.') as any
     render(
       <Provider store={store}>
         <I18nProvider>
           <ThemeProvider>
-            <App />
+            <SaveManagerProvider manager={manager}>
+              <App />
+            </SaveManagerProvider>
           </ThemeProvider>
         </I18nProvider>
       </Provider>

--- a/src/init.ts
+++ b/src/init.ts
@@ -23,7 +23,7 @@ async function needsRebuild(indexPath: string, courseDirs: string[]): Promise<bo
     const indexTime = stat.mtimeMs
     for (const dir of courseDirs) {
       const m = await newestMTime(path.join(dir, 'topics'))
-      if (m > indexTime) return true
+      if (m >= indexTime) return true
     }
     return false
   } catch {

--- a/src/initSave.ts
+++ b/src/initSave.ts
@@ -1,0 +1,36 @@
+import path from 'path'
+import { promises as fs } from 'fs'
+import { SaveManager } from './saveManager'
+import type { AppStore, UserState } from './store'
+
+export async function initSave(store: AppStore, rootDir = process.cwd()): Promise<SaveManager> {
+  const prefsPath = path.join(rootDir, 'save', 'prefs.json')
+  const prefs = JSON.parse(await fs.readFile(prefsPath, 'utf8'))
+  const profileDir = path.join(rootDir, prefs.profile)
+  const manager = new SaveManager(profileDir, {
+    onChange: () => {
+      const payload: UserState = {
+        mastery: manager.mastery,
+        attempts: manager.attempts,
+        xp: manager.xp,
+        prefs: manager.prefs,
+      }
+      store.dispatch({ type: 'user/setSave', payload })
+    },
+  })
+  try {
+    await manager.load()
+  } catch {
+    await manager.resetProfile()
+  }
+  store.dispatch({
+    type: 'user/setSave',
+    payload: {
+      mastery: manager.mastery,
+      attempts: manager.attempts,
+      xp: manager.xp,
+      prefs: manager.prefs,
+    },
+  })
+  return manager
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,25 +1,36 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App.tsx';
-import { I18nProvider } from './i18n.tsx';
-import { ThemeProvider } from './theme.tsx';
-import { Provider } from 'react-redux';
-import { store } from './store';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+import { I18nProvider } from './i18n.tsx'
+import { ThemeProvider } from './theme.tsx'
+import { Provider } from 'react-redux'
+import { store } from './store'
 import { ToastProvider } from './Toast'
-import 'mathjax/es5/tex-mml-chtml.js';
+import { SaveManagerProvider } from './saveContext'
+import { initSave } from './initSave'
+import { init } from './init'
+import 'mathjax/es5/tex-mml-chtml.js'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <Provider store={store}>
-      <I18nProvider>
-        <ThemeProvider>
-          <ToastProvider>
-            <App />
-          </ToastProvider>
-        </ThemeProvider>
-      </I18nProvider>
-    </Provider>
-  </StrictMode>,
-);
+async function bootstrap() {
+  await init(store)
+  const manager = await initSave(store)
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider>
+            <ToastProvider>
+              <SaveManagerProvider manager={manager}>
+                <App />
+              </SaveManagerProvider>
+            </ToastProvider>
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
+    </StrictMode>,
+  )
+}
+
+bootstrap()
 

--- a/src/saveContext.tsx
+++ b/src/saveContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useContext } from 'react'
+import { SaveManager } from './saveManager'
+
+const SaveManagerContext = createContext<SaveManager | null>(null)
+
+export function useSaveManager(): SaveManager {
+  const ctx = useContext(SaveManagerContext)
+  if (!ctx) throw new Error('SaveManager not initialized')
+  return ctx
+}
+
+export const SaveManagerProvider: React.FC<{
+  manager: SaveManager
+  children: React.ReactNode
+}> = ({ manager, children }) => (
+  <SaveManagerContext.Provider value={manager}>{children}</SaveManagerContext.Provider>
+)

--- a/src/saveManager.ts
+++ b/src/saveManager.ts
@@ -34,6 +34,7 @@ export interface SaveManagerOptions {
   toast?: (msg: string, actions?: ToastAction[]) => void
   initialDelayMs?: number
   maxDelayMs?: number
+  onChange?: (state: SaveState) => void
 }
 
 export class SaveManager implements SaveState {
@@ -61,6 +62,7 @@ export class SaveManager implements SaveState {
       const handler = async (curr: Stats, prev: Stats) => {
         if (curr.mtimeMs === prev.mtimeMs) return
         assign(JSON.parse(await fs.readFile(file, 'utf8')))
+        this.options.onChange?.(this)
       }
       watchFile(file, { persistent: false, interval }, handler)
       this.watchers.push({ file, handler })
@@ -107,6 +109,7 @@ export class SaveManager implements SaveState {
     this.xp = await loadWithMigrations<XpLog>(path.join(this.dir, 'xp.json'), 'XP-v1')
     this.prefs = await loadWithMigrations<Prefs>(path.join(this.dir, 'prefs.json'), 'Prefs-v2')
     this.watch()
+    this.options.onChange?.(this)
   }
 
   private async writeAll() {
@@ -179,6 +182,7 @@ export class SaveManager implements SaveState {
       await fs.copyFile(path.join(tmp, `${name}.json`), path.join(this.dir, `${name}.json`))
     }
     this.watch()
+    this.options.onChange?.(this)
   }
 
   async resetProfile() {
@@ -194,6 +198,7 @@ export class SaveManager implements SaveState {
     this.seedBlank()
     await this.writeAll()
     this.watch()
+    this.options.onChange?.(this)
   }
 }
 

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,10 +1,29 @@
-import React from 'react';
+import React from 'react'
+import { useSaveManager } from '../saveContext'
 
 export default function Settings() {
+  const manager = useSaveManager()
+
+  const doExport = () => {
+    const path = window.prompt('Export file', 'progress.zip')
+    if (path) manager.exportProgress(path)
+  }
+
+  const doImport = () => {
+    const path = window.prompt('Import file', 'progress.zip')
+    if (path) manager.importProgress(path)
+  }
+
+  const doReset = () => {
+    if (window.confirm('Reset profile?')) manager.resetProfile()
+  }
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-2">
       <h2 className="text-2xl font-bold mb-4">Settings</h2>
-      <p>Adjust your preferences.</p>
+      <button onClick={doImport} className="bg-blue-500 text-white px-4 py-2 rounded w-full">Import Progress</button>
+      <button onClick={doExport} className="bg-green-500 text-white px-4 py-2 rounded w-full">Export Progress</button>
+      <button onClick={doReset} className="bg-red-500 text-white px-4 py-2 rounded w-full">Reset Profile</button>
     </div>
-  );
+  )
 }

--- a/src/screens/__tests__/navigation.e2e.test.tsx
+++ b/src/screens/__tests__/navigation.e2e.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../../App'
+import { SaveManagerProvider } from '../../saveContext'
+import { SaveManager } from '../../saveManager'
 import { I18nProvider } from '../../i18n'
 import { ThemeProvider } from '../../theme'
 import { Provider } from 'react-redux'
@@ -8,11 +10,14 @@ import { createAppStore } from '../../store'
 describe('navigation between screens', () => {
   function setup() {
     const store = createAppStore()
+    const manager = new SaveManager('.') as any
     render(
       <Provider store={store}>
         <I18nProvider>
           <ThemeProvider>
-            <App />
+            <SaveManagerProvider manager={manager}>
+              <App />
+            </SaveManagerProvider>
           </ThemeProvider>
         </I18nProvider>
       </Provider>

--- a/src/screens/__tests__/screenHeadings.test.tsx
+++ b/src/screens/__tests__/screenHeadings.test.tsx
@@ -4,6 +4,8 @@ import Learning from '../Learning'
 import Progress from '../Progress'
 import Library from '../Library'
 import Settings from '../Settings'
+import { SaveManagerProvider } from '../../saveContext'
+import { SaveManager } from '../../saveManager'
 
 describe('screen headings match mockup', () => {
   it('home screen shows Dashboard heading', () => {
@@ -27,7 +29,12 @@ describe('screen headings match mockup', () => {
   })
 
   it('settings screen shows Settings heading', () => {
-    render(<Settings />)
+    const manager = new SaveManager('.') as any
+    render(
+      <SaveManagerProvider manager={manager}>
+        <Settings />
+      </SaveManagerProvider>
+    )
     expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
   })
 })

--- a/src/screens/__tests__/settingsActions.test.tsx
+++ b/src/screens/__tests__/settingsActions.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Settings from '../Settings'
+import { SaveManagerProvider } from '../../saveContext'
+import React from 'react'
+
+function setup(manager: any) {
+  render(
+    <SaveManagerProvider manager={manager}>
+      <Settings />
+    </SaveManagerProvider>
+  )
+}
+
+describe('settings actions', () => {
+  it('calls export/import/reset', () => {
+    const manager = {
+      exportProgress: vi.fn(),
+      importProgress: vi.fn(),
+      resetProfile: vi.fn(),
+    }
+    vi.spyOn(window, 'prompt').mockReturnValue('tmp.zip')
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    setup(manager)
+    fireEvent.click(screen.getByRole('button', { name: /import progress/i }))
+    expect(manager.importProgress).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /export progress/i }))
+    expect(manager.exportProgress).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /reset profile/i }))
+    expect(manager.resetProfile).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- initialize SaveManager using prefs profile
- propagate save changes into Redux via context callback
- expose SaveManager through React context
- call import/export/reset functions from settings screen
- adjust tests for new provider and add settings actions test
- loosen rebuild condition in init

## Testing
- `npm test`
- `npm run dev -- --port 5175` *(accessed via curl)*