### PR TITLE
Hide submit button after rating

### DIFF
--- a/js/views/LearningView.js
+++ b/js/views/LearningView.js
@@ -163,7 +163,7 @@ export class LearningView {
                     `).join('')}
                 </ul>
                 
-                <button class="btn btn-primary btn-full" 
+                <button id="submit-answer-btn" class="btn btn-primary btn-full"
                         onclick="app.learningView.submitAnswer()"
                         ${this.selectedAnswer === null ? 'disabled' : ''}>
                     Submit Answer
@@ -194,7 +194,7 @@ export class LearningView {
         });
         
         // Enable submit button
-        const submitBtn = document.querySelector('.btn-primary');
+        const submitBtn = document.getElementById('submit-answer-btn');
         if (submitBtn) {
             submitBtn.disabled = false;
         }
@@ -261,8 +261,8 @@ export class LearningView {
         }
 
         // Hide submit button
-        const submitBtn = document.querySelector('.btn-primary');
-        if (submitBtn && submitBtn.textContent === 'Submit Answer') {
+        const submitBtn = document.getElementById('submit-answer-btn');
+        if (submitBtn) {
             submitBtn.style.display = 'none';
         }
 

--- a/js/views/MixedQuizView.js
+++ b/js/views/MixedQuizView.js
@@ -108,7 +108,7 @@ export class MixedQuizView {
                     `).join('')}
                 </ul>
                 
-                <button class="btn btn-primary btn-full" 
+                <button id="submit-answer-btn" class="btn btn-primary btn-full"
                         onclick="app.mixedQuizView.submitAnswer()"
                         ${this.selectedAnswer === null ? 'disabled' : ''}>
                     Submit Answer
@@ -139,7 +139,7 @@ export class MixedQuizView {
         });
         
         // Enable submit button
-        const submitBtn = document.querySelector('.btn-primary');
+        const submitBtn = document.getElementById('submit-answer-btn');
         if (submitBtn) {
             submitBtn.disabled = false;
         }
@@ -206,8 +206,8 @@ export class MixedQuizView {
         }
 
         // Hide submit button
-        const submitBtn = document.querySelector('.btn-primary');
-        if (submitBtn && submitBtn.textContent === 'Submit Answer') {
+        const submitBtn = document.getElementById('submit-answer-btn');
+        if (submitBtn) {
             submitBtn.style.display = 'none';
         }
 


### PR DESCRIPTION
## Summary
- hide submit button during feedback by using a dedicated ID
- enable/disable via the new ID to prevent stale buttons

## Testing
- `npm test --silent`