### PR TITLE
Improve markdown rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.js">
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+    <script src="./node_modules/markdown-it/dist/markdown-it.min.js"></script>
 </head>
 <body>
     <div id="app">

--- a/js/views/LearningView.js
+++ b/js/views/LearningView.js
@@ -1,10 +1,10 @@
-import MarkdownIt from 'markdown-it';
+// import MarkdownIt from 'markdown-it';
 
 /**
  * LearningView
  * Handles the learning flow: exposition, questions, feedback, and ratings
  */
-const mdParser = new MarkdownIt();
+const mdParser = new window.markdownit();
 export class LearningView {
     constructor(courseManager) {
         this.courseManager = courseManager;

--- a/js/views/LearningView.js
+++ b/js/views/LearningView.js
@@ -1,7 +1,10 @@
+import MarkdownIt from 'markdown-it';
+
 /**
  * LearningView
  * Handles the learning flow: exposition, questions, feedback, and ratings
  */
+const mdParser = new MarkdownIt();
 export class LearningView {
     constructor(courseManager) {
         this.courseManager = courseManager;
@@ -375,11 +378,6 @@ export class LearningView {
     }
 
     renderMarkdown(text) {
-        // Basic markdown rendering (in production, use a proper markdown parser)
-        return text
-            .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-            .replace(/\*(.+?)\*/g, '<em>$1</em>')
-            .replace(/`(.+?)`/g, '<code>$1</code>')
-            .replace(/\n/g, '<br>');
+        return mdParser.render(text || '');
     }
 }

--- a/js/views/MixedQuizView.js
+++ b/js/views/MixedQuizView.js
@@ -1,10 +1,10 @@
-import MarkdownIt from 'markdown-it';
+// import MarkdownIt from 'markdown-it';
 
 /**
  * MixedQuizView
  * Handles mixed quiz sessions with questions from multiple mastered skills
  */
-const mdParser = new MarkdownIt();
+const mdParser = new window.markdownit();
 export class MixedQuizView {
     constructor(courseManager, taskSelector) {
         this.courseManager = courseManager;

--- a/js/views/MixedQuizView.js
+++ b/js/views/MixedQuizView.js
@@ -1,7 +1,10 @@
+import MarkdownIt from 'markdown-it';
+
 /**
  * MixedQuizView
  * Handles mixed quiz sessions with questions from multiple mastered skills
  */
+const mdParser = new MarkdownIt();
 export class MixedQuizView {
     constructor(courseManager, taskSelector) {
         this.courseManager = courseManager;
@@ -296,11 +299,6 @@ export class MixedQuizView {
     }
 
     renderMarkdown(text) {
-        // Basic markdown rendering
-        return text
-            .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-            .replace(/\*(.+?)\*/g, '<em>$1</em>')
-            .replace(/`(.+?)`/g, '<code>$1</code>')
-            .replace(/\n/g, '<br>');
+        return mdParser.render(text || '');
     }
 }

--- a/tests/views.test.js
+++ b/tests/views.test.js
@@ -108,3 +108,39 @@ describe('View Start Methods', () => {
         expect(mixedQuizView.showNoQuestionsAvailable).toHaveBeenCalled();
     });
 });
+
+describe('Markdown Rendering', () => {
+    test('LearningView.renderMarkdown parses lists, headings and math', () => {
+        const view = new LearningView();
+        const md = '# Title\n- item1\n- item2\n\nInline $x$';
+        const html = view.renderMarkdown(md);
+        expect(html).toContain('<h1>Title</h1>');
+        expect(html).toContain('<ul>');
+        expect(html).toContain('<li>item1</li>');
+        expect(html).toContain('<li>item2</li>');
+        expect(html).toContain('$x$');
+    });
+
+    test('MixedQuizView.renderMarkdown parses lists, headings and math', () => {
+        const view = new MixedQuizView();
+        const md = '## Heading\n1. one\n2. two\n\nEquation $y$';
+        const html = view.renderMarkdown(md);
+        expect(html).toContain('<h2>Heading</h2>');
+        expect(html).toContain('<ol>');
+        expect(html).toContain('<li>one</li>');
+        expect(html).toContain('<li>two</li>');
+        expect(html).toContain('$y$');
+    });
+
+    test('showExposition triggers MathJax typesetting', async () => {
+        const courseManager = { getSkillExplanation: vi.fn(async () => '# H\n') };
+        const view = new LearningView(courseManager);
+        view.currentSkill = { id: 'EA:AS001', title: 'Test' };
+
+        global.document = { getElementById: vi.fn(() => ({ innerHTML: '' })) };
+        global.window.MathJax = { typesetPromise: vi.fn() };
+
+        await view.showExposition();
+        expect(window.MathJax.typesetPromise).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- load markdown-it in LearningView and MixedQuizView
- replace regex renderers with markdown-it
- test markdown rendering for lists, headings, and inline math
- test that showExposition calls MathJax after rendering

## Testing
- `npm run test`