### PR TITLE
Fix content width when nav bar hidden

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -124,10 +124,14 @@ class SkillMasterApp {
         
         // Show/hide tab bar for learning views
         const tabBar = document.getElementById('tab-bar');
+        const mainContent = document.getElementById('main-content');
         if (viewName === 'learning' || viewName === 'mixedQuiz') {
             tabBar.style.display = 'none';
+            // Reset main content margin when tab bar is hidden (desktop layout)
+            mainContent.style.marginLeft = '0';
         } else {
             tabBar.style.display = '';
+            mainContent.style.marginLeft = '';
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the main content fills the page when the tab bar is hidden

## Testing
- `npm run test` *(fails: window.markdownit is not a constructor)*