### PR TITLE
Show multiple task options on home screen

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -147,6 +147,13 @@ body {
     margin: 24px 0;
 }
 
+.task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 12px;
+}
+
 .task-card {
     background-color: var(--bg-secondary);
     border-radius: 12px;

--- a/js/services/TaskSelector.js
+++ b/js/services/TaskSelector.js
@@ -13,23 +13,29 @@ export class TaskSelector {
      * @returns {Object|null} Next task {type: 'review'|'new'|'mixed_quiz', skillId?: string}
      */
     getNextTask() {
+        const tasks = this.getTopTasks(1);
+        return tasks.length > 0 ? tasks[0] : null;
+    }
+
+    /**
+     * Get the top N tasks ordered by priority
+     * @param {number} max - Maximum number of tasks to return
+     * @returns {Array} Array of tasks sorted by priority
+     */
+    getTopTasks(max = 1) {
         const candidates = this.getCandidates();
-        
+
         if (candidates.length === 0) {
-            return null;
+            return [];
         }
 
         // Sort by priority (highest first)
         candidates.sort((a, b) => b.priority - a.priority);
-        
+
         // Apply non-interference rule
         const validCandidates = this.applyNonInterference(candidates);
-        
-        if (validCandidates.length === 0) {
-            return null;
-        }
 
-        return validCandidates[0];
+        return validCandidates.slice(0, max);
     }
 
     /**

--- a/js/views/HomeView.js
+++ b/js/views/HomeView.js
@@ -14,7 +14,9 @@ export class HomeView {
         const xpProgress = (xpSinceMixed / 150) * 100;
         
         const overdueSkills = this.courseManager.masteryState.getOverdueSkills();
-        const nextTask = this.taskSelector.getNextTask();
+        const tasks = this.taskSelector.getTopTasks(6);
+        const nextTask = tasks.shift();
+        const additionalTasks = tasks;
         
         return `
             <div class="screen">
@@ -42,13 +44,21 @@ export class HomeView {
                 
                 <div class="next-task">
                     <h3>Next Task</h3>
-                    ${this.renderNextTask(nextTask)}
+                    ${this.renderTask(nextTask)}
                 </div>
+                ${additionalTasks.length > 0 ? `
+                <div class="additional-tasks">
+                    <h3>Other Options</h3>
+                    <div class="task-list">
+                        ${additionalTasks.map(t => this.renderTask(t)).join('')}
+                    </div>
+                </div>
+                ` : ''}
             </div>
         `;
     }
 
-    renderNextTask(task) {
+    renderTask(task) {
         if (!task) {
             return `
                 <div class="task-card">

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import MarkdownIt from 'markdown-it';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -27,3 +28,7 @@ global.fetch = async (path) => {
         };
     }
 };
+
+// Provide markdown-it constructor for views that expect window.markdownit
+global.window = global.window || {};
+global.window.markdownit = MarkdownIt;

--- a/tests/taskSelector.test.js
+++ b/tests/taskSelector.test.js
@@ -236,4 +236,20 @@ describe('TaskSelector', () => {
         expect(task.type).toBe('new');
         expect(task.skillId).toBe('TEST:AS001'); // First skill with no prereqs
     });
+
+    test('getTopTasks returns tasks sorted by priority', () => {
+        courseManager.masteryState.skills.set('TEST:AS001', {
+            status: 'in_progress',
+            next_due: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+        });
+        courseManager.masteryState.skills.set('TEST:AS002', {
+            status: 'in_progress',
+            next_due: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString()
+        });
+
+        const tasks = taskSelector.getTopTasks(2);
+        expect(tasks).toHaveLength(2);
+        expect(tasks[0].skillId).toBe('TEST:AS002');
+        expect(tasks[1].skillId).toBe('TEST:AS001');
+    });
 });

--- a/tests/views.test.js
+++ b/tests/views.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { LearningView } from '../js/views/LearningView.js';
 import { MixedQuizView } from '../js/views/MixedQuizView.js';
 import { LibraryView } from '../js/views/LibraryView.js';
+import { HomeView } from '../js/views/HomeView.js';
 import { CourseManager } from '../js/services/CourseManager.js';
 import { TaskSelector } from '../js/services/TaskSelector.js';
 
@@ -59,6 +60,27 @@ describe('View Render Methods', () => {
         expect(html).toContain('EA:AS004 -');
         expect(html).toContain('Prereqs');
         expect(html).toContain('Next review in');
+    });
+
+    test('HomeView render displays multiple tasks', () => {
+        const mockCourseManager = {
+            getTotalXP: vi.fn(() => 0),
+            prefs: { xp_since_mixed_quiz: 0 },
+            masteryState: { getOverdueSkills: vi.fn(() => []) },
+            getSkill: vi.fn(id => ({ id, title: id, desc: 'desc' }))
+        };
+        const mockTaskSelector = {
+            getTopTasks: vi.fn(() => [
+                { type: 'new', skillId: 'AS1', priority: 5 },
+                { type: 'new', skillId: 'AS2', priority: 4 }
+            ])
+        };
+
+        const homeView = new HomeView(mockCourseManager, mockTaskSelector);
+        const html = homeView.render();
+
+        expect(html).toContain('Next Task');
+        expect((html.match(/task-card/g) || []).length).toBe(2);
     });
 });
 


### PR DESCRIPTION
## Summary
- add `getTopTasks` to TaskSelector for retrieving several tasks
- update HomeView to display recommended task plus additional options
- style new task list with CSS
- ensure tests load `markdown-it` and test new functionality

## Testing
- `npm run test`